### PR TITLE
Add weather and date-time canvas widgets

### DIFF
--- a/src/domain/canvas.ts
+++ b/src/domain/canvas.ts
@@ -1,6 +1,6 @@
 import type { SearchProviderId, SearchVerticalId } from "./tabState";
 
-export type WidgetId = "search" | "shortcutGrid";
+export type WidgetId = "search" | "shortcutGrid" | "weather" | "dateTime";
 
 export type WidgetPlacement = {
   x: number;
@@ -41,6 +41,53 @@ export type ShortcutGridWidgetSettings = {
   visual: WidgetVisualSettings;
 };
 
+export type WeatherUnits = "celsius" | "fahrenheit";
+
+export type WeatherDisplayMode = "compact" | "standard" | "expanded";
+
+export type WeatherWidgetSettings = {
+  locationName: string;
+  latitude: number;
+  longitude: number;
+  units: WeatherUnits;
+  displayMode: WeatherDisplayMode;
+  showFeelsLike: boolean;
+  showHumidity: boolean;
+  showWind: boolean;
+  showPrecipitation: boolean;
+  refreshMinutes: number;
+  visual: WidgetVisualSettings;
+};
+
+export type DateTimeClockMode = "digital" | "percentageComplete" | "verticalClock";
+
+export type DateTimeFormat = "twentyFourHour" | "twelveHour";
+
+export type DateTimeDateMode = "hidden" | "long" | "short";
+
+export type DateTimeDateOrder = "DMY" | "MDY" | "YMD";
+
+export type DateTimeShortSeparator = "dash" | "dots" | "gaps" | "slashes";
+
+export type DateTimeWidgetSettings = {
+  clockMode: DateTimeClockMode;
+  timeFormat: DateTimeFormat;
+  showSeconds: boolean;
+  padHour: boolean;
+  dateMode: DateTimeDateMode;
+  dateOrder: DateTimeDateOrder;
+  shortSeparator: DateTimeShortSeparator;
+  showWeekday: boolean;
+  showOrdinalDay: boolean;
+  showWeekNumber: boolean;
+  padDate: boolean;
+  timezone: "auto" | string;
+  hourColor: string;
+  minuteColor: string;
+  secondColor: string;
+  visual: WidgetVisualSettings;
+};
+
 export type WidgetState<TSettings> = {
   enabled: boolean;
   placement: WidgetPlacement;
@@ -50,6 +97,8 @@ export type WidgetState<TSettings> = {
 export type CanvasWidgets = {
   search: WidgetState<SearchWidgetSettings>;
   shortcutGrid: WidgetState<ShortcutGridWidgetSettings>;
+  weather: WidgetState<WeatherWidgetSettings>;
+  dateTime: WidgetState<DateTimeWidgetSettings>;
 };
 
 export type CanvasState = {
@@ -68,6 +117,8 @@ const widgetGap = 2;
 const canvasBottomMargin = 1;
 const defaultSearchSize = { width: 11, height: 1 };
 const defaultShortcutGridSize = { width: 13, height: 7 };
+const defaultWeatherSize = { width: 5, height: 3 };
+const defaultDateTimeSize = { width: 7, height: 3 };
 
 export const defaultWidgetVisualSettings: WidgetVisualSettings = {
   showBackground: false,
@@ -108,6 +159,57 @@ export const defaultCanvasState: CanvasState = {
         showPageDots: true,
         visual: defaultWidgetVisualSettings
       }
+    },
+    weather: {
+      enabled: true,
+      placement: deriveDefaultWidgetPlacements(fallbackCanvasGrid).weather,
+      settings: {
+        locationName: "London",
+        latitude: 51.5072,
+        longitude: -0.1276,
+        units: "celsius",
+        displayMode: "expanded",
+        showFeelsLike: true,
+        showHumidity: true,
+        showWind: true,
+        showPrecipitation: true,
+        refreshMinutes: 10,
+        visual: {
+          ...defaultWidgetVisualSettings,
+          showBackground: true,
+          backgroundOpacity: 26,
+          radius: 22,
+          padding: 12
+        }
+      }
+    },
+    dateTime: {
+      enabled: true,
+      placement: deriveDefaultWidgetPlacements(fallbackCanvasGrid).dateTime,
+      settings: {
+        clockMode: "verticalClock",
+        timeFormat: "twentyFourHour",
+        showSeconds: true,
+        padHour: true,
+        dateMode: "long",
+        dateOrder: "DMY",
+        shortSeparator: "dots",
+        showWeekday: true,
+        showOrdinalDay: true,
+        showWeekNumber: false,
+        padDate: true,
+        timezone: "auto",
+        hourColor: "#f8fafc",
+        minuteColor: "#7dd3fc",
+        secondColor: "#fde68a",
+        visual: {
+          ...defaultWidgetVisualSettings,
+          showBackground: true,
+          backgroundOpacity: 26,
+          radius: 24,
+          padding: 14
+        }
+      }
     }
   }
 };
@@ -135,6 +237,10 @@ export function deriveDefaultWidgetPlacements(grid: CanvasGrid): Record<WidgetId
   const shortcutGridWidth = Math.min(defaultShortcutGridSize.width, grid.columns);
   const availableShortcutGridHeight = Math.max(1, grid.rows - shortcutGridY - canvasBottomMargin);
   const shortcutGridHeight = Math.min(defaultShortcutGridSize.height, availableShortcutGridHeight);
+  const weatherWidth = Math.min(defaultWeatherSize.width, grid.columns);
+  const weatherHeight = Math.min(defaultWeatherSize.height, grid.rows);
+  const dateTimeWidth = Math.min(defaultDateTimeSize.width, grid.columns);
+  const dateTimeHeight = Math.min(defaultDateTimeSize.height, grid.rows);
 
   return {
     search: searchPlacement,
@@ -145,6 +251,26 @@ export function deriveDefaultWidgetPlacements(grid: CanvasGrid): Record<WidgetId
         width: shortcutGridWidth,
         height: shortcutGridHeight,
         zIndex: 5
+      },
+      grid
+    ),
+    weather: clampPlacementToCanvas(
+      {
+        x: 0,
+        y: Math.max(0, grid.rows - weatherHeight),
+        width: weatherWidth,
+        height: weatherHeight,
+        zIndex: 8
+      },
+      grid
+    ),
+    dateTime: clampPlacementToCanvas(
+      {
+        x: 0,
+        y: 0,
+        width: dateTimeWidth,
+        height: dateTimeHeight,
+        zIndex: 8
       },
       grid
     )
@@ -267,6 +393,15 @@ function isKnownDefaultWidgetPlacement(widgetId: WidgetId, placement: WidgetPlac
       { x: 7, y: 5, width: 13, height: 7, zIndex: 5 },
       { x: 4, y: 6, width: 26, height: 10, zIndex: 5 },
       { x: 12.5, y: 5.5, width: 9, height: 8, zIndex: 5 }
+    ],
+    weather: [
+      fallbackDefaults.weather,
+      { x: 29, y: 0, width: 5, height: 2, zIndex: 8 },
+      { x: 0, y: 16, width: 5, height: 3, zIndex: 8 }
+    ],
+    dateTime: [
+      fallbackDefaults.dateTime,
+      { x: 0, y: 0, width: 7, height: 3, zIndex: 8 }
     ]
   };
 

--- a/src/domain/tabState.ts
+++ b/src/domain/tabState.ts
@@ -1,5 +1,15 @@
 import type { BrandIconId } from "./brandIcons";
-import { defaultCanvasState, type CanvasState } from "./canvas";
+import {
+  defaultCanvasState,
+  type CanvasState,
+  type DateTimeClockMode,
+  type DateTimeDateMode,
+  type DateTimeDateOrder,
+  type DateTimeFormat,
+  type DateTimeShortSeparator,
+  type WeatherDisplayMode,
+  type WeatherUnits
+} from "./canvas";
 import { defaultThemeId, isThemeId, type ThemeId } from "./themes";
 
 export type SearchProviderId = "google" | "bing" | "yahoo" | "yandex" | "duckduckgo";
@@ -427,7 +437,9 @@ export function normalizeCanvasState(value: unknown, fallbackState?: Partial<Tab
             ),
             showLabels: legacyLayout?.showLabels ?? fallback.widgets.shortcutGrid.settings.showLabels
           }
-        }
+        },
+        weather: fallback.widgets.weather,
+        dateTime: fallback.widgets.dateTime
       }
     };
   }
@@ -437,7 +449,9 @@ export function normalizeCanvasState(value: unknown, fallbackState?: Partial<Tab
     targetCellSize: clampInteger(value.targetCellSize, 48, 72, fallback.targetCellSize),
     widgets: {
       search: normalizeSearchWidget(widgets.search, fallback.widgets.search, legacySearchProvider),
-      shortcutGrid: normalizeShortcutGridWidget(widgets.shortcutGrid, fallback.widgets.shortcutGrid)
+      shortcutGrid: normalizeShortcutGridWidget(widgets.shortcutGrid, fallback.widgets.shortcutGrid),
+      weather: normalizeWeatherWidget(widgets.weather, fallback.widgets.weather),
+      dateTime: normalizeDateTimeWidget(widgets.dateTime, fallback.widgets.dateTime)
     }
   };
 }
@@ -495,6 +509,74 @@ function normalizeShortcutGridWidget(
       lineSpacing: clampInteger(settings.lineSpacing, 0, 100, fallback.settings.lineSpacing),
       showLabels: typeof settings.showLabels === "boolean" ? settings.showLabels : fallback.settings.showLabels,
       showPageDots: typeof settings.showPageDots === "boolean" ? settings.showPageDots : fallback.settings.showPageDots,
+      visual: normalizeWidgetVisualSettings(settings.visual, fallback.settings.visual)
+    }
+  };
+}
+
+function normalizeWeatherWidget(
+  value: unknown,
+  fallback: CanvasState["widgets"]["weather"]
+): CanvasState["widgets"]["weather"] {
+  if (!isRecord(value)) {
+    return fallback;
+  }
+
+  const settings = isRecord(value.settings) ? value.settings : {};
+  return {
+    enabled: typeof value.enabled === "boolean" ? value.enabled : fallback.enabled,
+    placement: normalizeWidgetPlacement(value.placement, fallback.placement),
+    settings: {
+      ...fallback.settings,
+      locationName: normalizeLocationName(settings.locationName, fallback.settings.locationName),
+      latitude: clampNumber(settings.latitude, -90, 90, fallback.settings.latitude),
+      longitude: clampNumber(settings.longitude, -180, 180, fallback.settings.longitude),
+      units: isWeatherUnits(settings.units) ? settings.units : fallback.settings.units,
+      displayMode: isWeatherDisplayMode(settings.displayMode) ? settings.displayMode : fallback.settings.displayMode,
+      showFeelsLike: typeof settings.showFeelsLike === "boolean" ? settings.showFeelsLike : fallback.settings.showFeelsLike,
+      showHumidity: typeof settings.showHumidity === "boolean" ? settings.showHumidity : fallback.settings.showHumidity,
+      showWind: typeof settings.showWind === "boolean" ? settings.showWind : fallback.settings.showWind,
+      showPrecipitation:
+        typeof settings.showPrecipitation === "boolean" ? settings.showPrecipitation : fallback.settings.showPrecipitation,
+      refreshMinutes: clampInteger(settings.refreshMinutes, 5, 120, fallback.settings.refreshMinutes),
+      visual: normalizeWidgetVisualSettings(settings.visual, fallback.settings.visual)
+    }
+  };
+}
+
+function normalizeDateTimeWidget(
+  value: unknown,
+  fallback: CanvasState["widgets"]["dateTime"]
+): CanvasState["widgets"]["dateTime"] {
+  if (!isRecord(value)) {
+    return fallback;
+  }
+
+  const settings = isRecord(value.settings) ? value.settings : {};
+  return {
+    enabled: typeof value.enabled === "boolean" ? value.enabled : fallback.enabled,
+    placement: normalizeWidgetPlacement(value.placement, fallback.placement),
+    settings: {
+      ...fallback.settings,
+      clockMode: isDateTimeClockMode(settings.clockMode) ? settings.clockMode : fallback.settings.clockMode,
+      timeFormat: isDateTimeFormat(settings.timeFormat) ? settings.timeFormat : fallback.settings.timeFormat,
+      showSeconds: typeof settings.showSeconds === "boolean" ? settings.showSeconds : fallback.settings.showSeconds,
+      padHour: typeof settings.padHour === "boolean" ? settings.padHour : fallback.settings.padHour,
+      dateMode: isDateTimeDateMode(settings.dateMode) ? settings.dateMode : fallback.settings.dateMode,
+      dateOrder: isDateTimeDateOrder(settings.dateOrder) ? settings.dateOrder : fallback.settings.dateOrder,
+      shortSeparator: isDateTimeShortSeparator(settings.shortSeparator)
+        ? settings.shortSeparator
+        : fallback.settings.shortSeparator,
+      showWeekday: typeof settings.showWeekday === "boolean" ? settings.showWeekday : fallback.settings.showWeekday,
+      showOrdinalDay:
+        typeof settings.showOrdinalDay === "boolean" ? settings.showOrdinalDay : fallback.settings.showOrdinalDay,
+      showWeekNumber:
+        typeof settings.showWeekNumber === "boolean" ? settings.showWeekNumber : fallback.settings.showWeekNumber,
+      padDate: typeof settings.padDate === "boolean" ? settings.padDate : fallback.settings.padDate,
+      timezone: normalizeTimezone(settings.timezone, fallback.settings.timezone),
+      hourColor: normalizeColorString(settings.hourColor, fallback.settings.hourColor),
+      minuteColor: normalizeColorString(settings.minuteColor, fallback.settings.minuteColor),
+      secondColor: normalizeColorString(settings.secondColor, fallback.settings.secondColor),
       visual: normalizeWidgetVisualSettings(settings.visual, fallback.settings.visual)
     }
   };
@@ -805,6 +887,64 @@ function isSearchVerticalId(value: unknown): value is SearchVerticalId {
 
 function isGridLayoutPresetId(value: unknown): value is GridLayoutPresetId {
   return typeof value === "string" && value in gridLayoutPresets;
+}
+
+function isWeatherUnits(value: unknown): value is WeatherUnits {
+  return value === "celsius" || value === "fahrenheit";
+}
+
+function isWeatherDisplayMode(value: unknown): value is WeatherDisplayMode {
+  return value === "compact" || value === "standard" || value === "expanded";
+}
+
+function isDateTimeClockMode(value: unknown): value is DateTimeClockMode {
+  return value === "digital" || value === "percentageComplete" || value === "verticalClock";
+}
+
+function isDateTimeFormat(value: unknown): value is DateTimeFormat {
+  return value === "twentyFourHour" || value === "twelveHour";
+}
+
+function isDateTimeDateMode(value: unknown): value is DateTimeDateMode {
+  return value === "hidden" || value === "long" || value === "short";
+}
+
+function isDateTimeDateOrder(value: unknown): value is DateTimeDateOrder {
+  return value === "DMY" || value === "MDY" || value === "YMD";
+}
+
+function isDateTimeShortSeparator(value: unknown): value is DateTimeShortSeparator {
+  return value === "dash" || value === "dots" || value === "gaps" || value === "slashes";
+}
+
+function normalizeTimezone(value: unknown, fallback: string) {
+  if (typeof value !== "string") {
+    return fallback;
+  }
+
+  const trimmed = value.trim();
+  return trimmed === "auto" || (trimmed.length > 0 && trimmed.length <= 80) ? trimmed : fallback;
+}
+
+function normalizeColorString(value: unknown, fallback: string) {
+  return typeof value === "string" && value.trim().length > 0 && value.length <= 32 ? value : fallback;
+}
+
+function normalizeLocationName(value: unknown, fallback: string) {
+  if (typeof value !== "string") {
+    return fallback;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 && trimmed.length <= 80 ? trimmed : fallback;
+}
+
+function clampNumber(value: unknown, min: number, max: number, fallback: number) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+
+  return Math.min(max, Math.max(min, value));
 }
 
 function clampInteger(value: unknown, min: number, max: number, fallback: number) {

--- a/src/ui/app/useNewTabController.ts
+++ b/src/ui/app/useNewTabController.ts
@@ -31,8 +31,10 @@ import {
 import { applyDropAction, type DropAction } from "../../domain/dropActions";
 import {
   type CanvasGrid,
+  type DateTimeWidgetSettings,
   type SearchWidgetSettings,
   type ShortcutGridWidgetSettings,
+  type WeatherWidgetSettings,
   type WidgetId,
   type WidgetPlacement,
   findNearestFreePlacement,
@@ -161,6 +163,22 @@ export function useNewTabController() {
     updateTabState((state) =>
       produce(state, (draft) => {
         draft.canvas.widgets.shortcutGrid.settings[key] = value;
+      })
+    );
+  }
+
+  function changeWeatherWidgetSetting<K extends keyof WeatherWidgetSettings>(key: K, value: WeatherWidgetSettings[K]) {
+    updateTabState((state) =>
+      produce(state, (draft) => {
+        draft.canvas.widgets.weather.settings[key] = value;
+      })
+    );
+  }
+
+  function changeDateTimeWidgetSetting<K extends keyof DateTimeWidgetSettings>(key: K, value: DateTimeWidgetSettings[K]) {
+    updateTabState((state) =>
+      produce(state, (draft) => {
+        draft.canvas.widgets.dateTime.settings[key] = value;
       })
     );
   }
@@ -382,8 +400,10 @@ export function useNewTabController() {
     activeShortcutPage,
     backupMessage,
     changeLayout,
+    changeDateTimeWidgetSetting,
     changeSearchProvider,
     changeSearchWidgetSetting,
+    changeWeatherWidgetSetting,
     changeShortcutGridWidgetSetting,
     changeTheme,
     changeWallpaperSetting,

--- a/src/ui/canvas/CanvasWidgetHost.tsx
+++ b/src/ui/canvas/CanvasWidgetHost.tsx
@@ -2,8 +2,10 @@ import { MouseEvent, useEffect, useState, type RefObject } from "react";
 import {
   resolveResponsiveDefaultWidgetPlacement,
   type CanvasGrid,
+  type DateTimeWidgetSettings,
   type SearchWidgetSettings,
   type ShortcutGridWidgetSettings,
+  type WeatherWidgetSettings,
   type WidgetId,
   type WidgetPlacement
 } from "../../domain/canvas";
@@ -15,6 +17,8 @@ import { WidgetContextMenu, type ContextMenuState } from "../widgets/WidgetConte
 import { WidgetFrame } from "../widgets/WidgetFrame";
 import { SearchWidget } from "../widgets/search";
 import { ShortcutGridWidget } from "../widgets/shortcut-grid";
+import { WeatherWidget } from "../widgets/weather";
+import { DateTimeWidget } from "../widgets/date-time";
 import { CanvasSurface } from "./CanvasSurface";
 
 type CanvasMetrics = ReturnType<typeof import("./useCanvasMetrics").useCanvasMetrics>;
@@ -22,12 +26,14 @@ type CanvasMetrics = ReturnType<typeof import("./useCanvasMetrics").useCanvasMet
 export type CanvasWidgetController = {
   activeSearchProvider: (typeof searchProviders)[SearchProviderId];
   activeShortcutPage: number;
+  changeDateTimeWidgetSetting: <K extends keyof DateTimeWidgetSettings>(key: K, value: DateTimeWidgetSettings[K]) => void;
   changeSearchProvider: (providerId: SearchProviderId) => void;
   changeSearchWidgetSetting: <K extends keyof SearchWidgetSettings>(key: K, value: SearchWidgetSettings[K]) => void;
   changeShortcutGridWidgetSetting: <K extends keyof ShortcutGridWidgetSettings>(
     key: K,
     value: ShortcutGridWidgetSettings[K]
   ) => void;
+  changeWeatherWidgetSetting: <K extends keyof WeatherWidgetSettings>(key: K, value: WeatherWidgetSettings[K]) => void;
   dispatchDropAction: (action: DropAction) => void;
   gridRef: RefObject<HTMLElement | null>;
   hasOverlayOpen: boolean;
@@ -65,12 +71,16 @@ export function CanvasWidgetHost({
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   const shortcutGridWidget = tabState.canvas.widgets.shortcutGrid;
   const searchWidget = tabState.canvas.widgets.search;
+  const weatherWidget = tabState.canvas.widgets.weather;
+  const dateTimeWidget = tabState.canvas.widgets.dateTime;
   const searchPlacement = resolveResponsiveDefaultWidgetPlacement("search", searchWidget.placement, canvasMetrics);
   const shortcutGridPlacement = resolveResponsiveDefaultWidgetPlacement(
     "shortcutGrid",
     shortcutGridWidget.placement,
     canvasMetrics
   );
+  const weatherPlacement = resolveResponsiveDefaultWidgetPlacement("weather", weatherWidget.placement, canvasMetrics);
+  const dateTimePlacement = resolveResponsiveDefaultWidgetPlacement("dateTime", dateTimeWidget.placement, canvasMetrics);
 
   useEffect(() => {
     if (!contextMenu) {
@@ -96,7 +106,7 @@ export function CanvasWidgetHost({
     setContextMenu({ type: "canvas", x: event.clientX, y: event.clientY });
   }
 
-  function openWidgetContextMenu(widgetId: "search" | "shortcutGrid", event: MouseEvent<HTMLElement>) {
+  function openWidgetContextMenu(widgetId: WidgetId, event: MouseEvent<HTMLElement>) {
     if (!isCanvasEditMode) {
       return;
     }
@@ -109,6 +119,20 @@ export function CanvasWidgetHost({
   return (
     <>
       <CanvasSurface editMode={isCanvasEditMode} metrics={canvasMetrics} onCanvasContextMenu={openCanvasContextMenu}>
+        <WidgetFrame
+          editMode={isCanvasEditMode}
+          enabled={dateTimeWidget.enabled}
+          label="Date & Time Widget"
+          metrics={canvasMetrics}
+          onMove={(placement) => controller.updateWidgetPlacement("dateTime", placement, canvasMetrics)}
+          onResize={(placement) => controller.updateWidgetPlacement("dateTime", placement, canvasMetrics)}
+          onWidgetContextMenu={openWidgetContextMenu}
+          placement={dateTimePlacement}
+          widgetId="dateTime"
+        >
+          <DateTimeWidget settings={dateTimeWidget.settings} />
+        </WidgetFrame>
+
         <WidgetFrame
           editMode={isCanvasEditMode}
           enabled={searchWidget.enabled}
@@ -128,6 +152,20 @@ export function CanvasWidgetHost({
             setQuery={setQuery}
             settings={searchWidget.settings}
           />
+        </WidgetFrame>
+
+        <WidgetFrame
+          editMode={isCanvasEditMode}
+          enabled={weatherWidget.enabled}
+          label="Weather Widget"
+          metrics={canvasMetrics}
+          onMove={(placement) => controller.updateWidgetPlacement("weather", placement, canvasMetrics)}
+          onResize={(placement) => controller.updateWidgetPlacement("weather", placement, canvasMetrics)}
+          onWidgetContextMenu={openWidgetContextMenu}
+          placement={weatherPlacement}
+          widgetId="weather"
+        >
+          <WeatherWidget settings={weatherWidget.settings} />
         </WidgetFrame>
 
         <WidgetFrame
@@ -167,6 +205,8 @@ export function CanvasWidgetHost({
         <WidgetContextMenu
           changeSearchWidgetSetting={controller.changeSearchWidgetSetting}
           changeShortcutGridWidgetSetting={controller.changeShortcutGridWidgetSetting}
+          changeWeatherWidgetSetting={controller.changeWeatherWidgetSetting}
+          changeDateTimeWidgetSetting={controller.changeDateTimeWidgetSetting}
           close={() => setContextMenu(null)}
           menu={contextMenu}
           setWidgetEnabled={(widgetId, enabled) => controller.setWidgetEnabled(widgetId, enabled, canvasMetrics)}

--- a/src/ui/widgets/WidgetContextMenu.tsx
+++ b/src/ui/widgets/WidgetContextMenu.tsx
@@ -1,19 +1,23 @@
 import type { CSSProperties } from "react";
 import type { TabState } from "../../domain/tabState";
-import type { SearchWidgetSettings, ShortcutGridWidgetSettings, WidgetId } from "../../domain/canvas";
+import type { DateTimeWidgetSettings, SearchWidgetSettings, ShortcutGridWidgetSettings, WeatherWidgetSettings, WidgetId } from "../../domain/canvas";
+import { DateTimeWidgetContextMenu } from "./date-time";
 import { SearchWidgetContextMenu } from "./search";
 import { ShortcutGridWidgetContextMenu } from "./shortcut-grid";
+import { WeatherWidgetContextMenu } from "./weather";
 
 type ContextMenuState =
   | { type: "canvas"; x: number; y: number }
   | { type: "widget"; widgetId: WidgetId; x: number; y: number };
 
 type WidgetContextMenuProps = {
+  changeDateTimeWidgetSetting: <K extends keyof DateTimeWidgetSettings>(key: K, value: DateTimeWidgetSettings[K]) => void;
   changeSearchWidgetSetting: <K extends keyof SearchWidgetSettings>(key: K, value: SearchWidgetSettings[K]) => void;
   changeShortcutGridWidgetSetting: <K extends keyof ShortcutGridWidgetSettings>(
     key: K,
     value: ShortcutGridWidgetSettings[K]
   ) => void;
+  changeWeatherWidgetSetting: <K extends keyof WeatherWidgetSettings>(key: K, value: WeatherWidgetSettings[K]) => void;
   close: () => void;
   menu: ContextMenuState;
   setWidgetEnabled: (widgetId: WidgetId, enabled: boolean) => void;
@@ -23,8 +27,10 @@ type WidgetContextMenuProps = {
 export type { ContextMenuState };
 
 export function WidgetContextMenu({
+  changeDateTimeWidgetSetting,
   changeSearchWidgetSetting,
   changeShortcutGridWidgetSetting,
+  changeWeatherWidgetSetting,
   close,
   menu,
   setWidgetEnabled,
@@ -33,6 +39,8 @@ export function WidgetContextMenu({
   // This shell owns menu positioning and Canvas-level toggles; each Widget owns its settings section.
   const searchWidget = tabState.canvas.widgets.search;
   const shortcutGridWidget = tabState.canvas.widgets.shortcutGrid;
+  const weatherWidget = tabState.canvas.widgets.weather;
+  const dateTimeWidget = tabState.canvas.widgets.dateTime;
   const style = {
     "--context-menu-x": `${menu.x}px`,
     "--context-menu-y": `${menu.y}px`
@@ -68,6 +76,22 @@ export function WidgetContextMenu({
                 type="checkbox"
               />
             </label>
+            <label className="context-toggle-row">
+              <span>Date & Time Widget</span>
+              <input
+                checked={dateTimeWidget.enabled}
+                onChange={(event) => setWidgetEnabled("dateTime", event.target.checked)}
+                type="checkbox"
+              />
+            </label>
+            <label className="context-toggle-row">
+              <span>Weather Widget</span>
+              <input
+                checked={weatherWidget.enabled}
+                onChange={(event) => setWidgetEnabled("weather", event.target.checked)}
+                type="checkbox"
+              />
+            </label>
           </>
         ) : menu.widgetId === "search" ? (
           <SearchWidgetContextMenu
@@ -75,11 +99,23 @@ export function WidgetContextMenu({
             searchWidget={searchWidget}
             setEnabled={(enabled) => setWidgetEnabled("search", enabled)}
           />
-        ) : (
+        ) : menu.widgetId === "shortcutGrid" ? (
           <ShortcutGridWidgetContextMenu
             changeShortcutGridWidgetSetting={changeShortcutGridWidgetSetting}
             setEnabled={(enabled) => setWidgetEnabled("shortcutGrid", enabled)}
             shortcutGridWidget={shortcutGridWidget}
+          />
+        ) : menu.widgetId === "dateTime" ? (
+          <DateTimeWidgetContextMenu
+            changeDateTimeWidgetSetting={changeDateTimeWidgetSetting}
+            dateTimeWidget={dateTimeWidget}
+            setEnabled={(enabled) => setWidgetEnabled("dateTime", enabled)}
+          />
+        ) : (
+          <WeatherWidgetContextMenu
+            changeWeatherWidgetSetting={changeWeatherWidgetSetting}
+            setEnabled={(enabled) => setWidgetEnabled("weather", enabled)}
+            weatherWidget={weatherWidget}
           />
         )}
       </section>

--- a/src/ui/widgets/WidgetContextMenuControls.tsx
+++ b/src/ui/widgets/WidgetContextMenuControls.tsx
@@ -1,3 +1,5 @@
+import type { WidgetVisualSettings } from "../../domain/canvas";
+
 type RangeRowProps = {
   label: string;
   max: number;
@@ -14,5 +16,23 @@ export function RangeRow({ label, max, min, onChange, suffix, value }: RangeRowP
       <input min={min} max={max} onChange={(event) => onChange(Number(event.target.value))} type="range" value={value} />
       <output>{value}{suffix}</output>
     </label>
+  );
+}
+
+type WidgetVisualControlsProps = {
+  onChange: (visual: WidgetVisualSettings) => void;
+  visual: WidgetVisualSettings;
+};
+
+export function WidgetVisualControls({ onChange, visual }: WidgetVisualControlsProps) {
+  return (
+    <RangeRow
+      label="Translucence"
+      max={100}
+      min={0}
+      onChange={(value) => onChange({ ...visual, backgroundOpacity: value })}
+      suffix="%"
+      value={visual.backgroundOpacity}
+    />
   );
 }

--- a/src/ui/widgets/date-time/DateTimeWidget.tsx
+++ b/src/ui/widgets/date-time/DateTimeWidget.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useMemo, useState, type CSSProperties } from "react";
+import type { DateTimeWidgetSettings } from "../../../domain/canvas";
+import { getWidgetSurfaceStyle } from "../widgetSurface";
+
+type DateTimeWidgetProps = {
+  settings: DateTimeWidgetSettings;
+};
+
+const separators: Record<DateTimeWidgetSettings["shortSeparator"], string> = {
+  dash: "-",
+  dots: ".",
+  gaps: " ",
+  slashes: "/"
+};
+
+export function DateTimeWidget({ settings }: DateTimeWidgetProps) {
+  const now = useCurrentDate(settings);
+  const surfaceStyle = getDateTimeSurfaceStyle(settings);
+  const timeParts = getTimeParts(now, settings);
+  const dateText = getDateText(now, settings);
+  const weekText = settings.showWeekNumber ? `Week ${getIsoWeekNumber(now)}` : null;
+
+  return (
+    <section className="date-time-widget widget-surface" aria-label="Date and time" style={surfaceStyle}>
+      <ClockView now={now} settings={settings} timeParts={timeParts} />
+      {settings.dateMode !== "hidden" ? (
+        <div className="date-time-date-group">
+          <span>{dateText}</span>
+          {weekText ? <small>{weekText}</small> : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function ClockView({
+  now,
+  settings,
+  timeParts
+}: {
+  now: Date;
+  settings: DateTimeWidgetSettings;
+  timeParts: ReturnType<typeof getTimeParts>;
+}) {
+  if (settings.clockMode === "percentageComplete") {
+    const percent = getDayPercent(now);
+    return (
+      <div className="date-time-percentage" aria-label={`${percent}% of today complete`}>
+        <strong>{percent}%</strong>
+        <span>day complete</span>
+      </div>
+    );
+  }
+
+  if (settings.clockMode === "verticalClock") {
+    return (
+      <div className="date-time-vertical" aria-label={timeParts.accessibleLabel}>
+        <strong style={{ color: settings.hourColor }}>{timeParts.hour}</strong>
+        <strong style={{ color: settings.minuteColor }}>{timeParts.minute}</strong>
+        {settings.showSeconds ? <strong style={{ color: settings.secondColor }}>{timeParts.second}</strong> : null}
+        {timeParts.period ? <span>{timeParts.period}</span> : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className="date-time-digital" aria-label={timeParts.accessibleLabel}>
+      <strong>
+        {timeParts.hour}<span>:</span>{timeParts.minute}{settings.showSeconds ? <><span>:</span>{timeParts.second}</> : null}
+      </strong>
+      {timeParts.period ? <span>{timeParts.period}</span> : null}
+    </div>
+  );
+}
+
+function useCurrentDate(settings: DateTimeWidgetSettings) {
+  const [now, setNow] = useState(() => new Date());
+  const tickToSecond = settings.showSeconds || settings.clockMode === "verticalClock";
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    function scheduleNextTick() {
+      setNow(new Date());
+      const current = Date.now();
+      const interval = tickToSecond ? 1000 : 60_000;
+      timer = setTimeout(scheduleNextTick, interval - (current % interval));
+    }
+
+    function resyncWhenVisible() {
+      if (document.visibilityState === "visible") {
+        setNow(new Date());
+      }
+    }
+
+    scheduleNextTick();
+    document.addEventListener("visibilitychange", resyncWhenVisible);
+    return () => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+      document.removeEventListener("visibilitychange", resyncWhenVisible);
+    };
+  }, [tickToSecond, settings.timezone]);
+
+  return now;
+}
+
+function getTimeParts(now: Date, settings: DateTimeWidgetSettings) {
+  const timeZone = settings.timezone === "auto" ? undefined : settings.timezone;
+  const parts = new Intl.DateTimeFormat("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    second: settings.showSeconds ? "2-digit" : undefined,
+    hour12: settings.timeFormat === "twelveHour",
+    timeZone
+  }).formatToParts(now);
+  const getPart = (type: string) => parts.find((part) => part.type === type)?.value ?? "";
+  const rawHour = getPart("hour");
+  const hour = settings.padHour && rawHour.length === 1 ? `0${rawHour}` : rawHour;
+  const minute = getPart("minute");
+  const second = getPart("second");
+  const period = getPart("dayPeriod");
+  const accessibleLabel = [hour, minute, settings.showSeconds ? second : null, period].filter(Boolean).join(" ");
+
+  return { hour, minute, second, period, accessibleLabel };
+}
+
+function getDateText(now: Date, settings: DateTimeWidgetSettings) {
+  if (settings.dateMode === "short") {
+    return getShortDateText(now, settings);
+  }
+
+  return getLongDateText(now, settings);
+}
+
+function getLongDateText(now: Date, settings: DateTimeWidgetSettings) {
+  const timeZone = settings.timezone === "auto" ? undefined : settings.timezone;
+  const weekday = settings.showWeekday
+    ? new Intl.DateTimeFormat("en-US", { weekday: "long", timeZone }).format(now)
+    : null;
+  const dayValue = new Intl.DateTimeFormat("en-US", { day: "numeric", timeZone }).format(now);
+  const day = settings.showOrdinalDay ? ordinal(Number(dayValue)) : dayValue;
+  const month = new Intl.DateTimeFormat("en-US", { month: "long", timeZone }).format(now);
+  const year = new Intl.DateTimeFormat("en-US", { year: "numeric", timeZone }).format(now);
+  const ordered = orderDateParts(settings.dateOrder, { day, month, year });
+
+  return [weekday, ordered.join(" ")].filter(Boolean).join(", ");
+}
+
+function getShortDateText(now: Date, settings: DateTimeWidgetSettings) {
+  const timeZone = settings.timezone === "auto" ? undefined : settings.timezone;
+  const parts = new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    month: "numeric",
+    year: "numeric",
+    timeZone
+  }).formatToParts(now);
+  const readPart = (type: string) => parts.find((part) => part.type === type)?.value ?? "";
+  const pad = (value: string) => (settings.padDate && value.length === 1 ? `0${value}` : value);
+  const separator = separators[settings.shortSeparator];
+  return orderDateParts(settings.dateOrder, {
+    day: pad(readPart("day")),
+    month: pad(readPart("month")),
+    year: readPart("year")
+  }).join(separator);
+}
+
+function orderDateParts(order: DateTimeWidgetSettings["dateOrder"], parts: { day: string; month: string; year: string }) {
+  if (order === "MDY") {
+    return [parts.month, parts.day, parts.year];
+  }
+
+  if (order === "YMD") {
+    return [parts.year, parts.month, parts.day];
+  }
+
+  return [parts.day, parts.month, parts.year];
+}
+
+function ordinal(value: number) {
+  const mod10 = value % 10;
+  const mod100 = value % 100;
+  if (mod10 === 1 && mod100 !== 11) return `${value}st`;
+  if (mod10 === 2 && mod100 !== 12) return `${value}nd`;
+  if (mod10 === 3 && mod100 !== 13) return `${value}rd`;
+  return `${value}th`;
+}
+
+function getDayPercent(now: Date) {
+  const elapsed = now.getHours() * 3600 + now.getMinutes() * 60 + now.getSeconds();
+  return Math.floor((elapsed / 86_400) * 100);
+}
+
+function getIsoWeekNumber(now: Date) {
+  const date = new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
+  const day = date.getUTCDay() || 7;
+  date.setUTCDate(date.getUTCDate() + 4 - day);
+  const yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1));
+  return Math.ceil(((date.getTime() - yearStart.getTime()) / 86_400_000 + 1) / 7);
+}
+
+function getDateTimeSurfaceStyle(settings: DateTimeWidgetSettings) {
+  return {
+    ...getWidgetSurfaceStyle(settings),
+    "--widget-padding": "clamp(14px, 8%, 22px)",
+    "--widget-radius": "26px"
+  } as CSSProperties;
+}

--- a/src/ui/widgets/date-time/DateTimeWidgetContextMenu.tsx
+++ b/src/ui/widgets/date-time/DateTimeWidgetContextMenu.tsx
@@ -1,0 +1,146 @@
+import type {
+  DateTimeClockMode,
+  DateTimeDateMode,
+  DateTimeDateOrder,
+  DateTimeFormat,
+  DateTimeShortSeparator,
+  DateTimeWidgetSettings,
+  WidgetState
+} from "../../../domain/canvas";
+import { WidgetVisualControls } from "../WidgetContextMenuControls";
+
+type DateTimeWidgetContextMenuProps = {
+  changeDateTimeWidgetSetting: <K extends keyof DateTimeWidgetSettings>(key: K, value: DateTimeWidgetSettings[K]) => void;
+  dateTimeWidget: WidgetState<DateTimeWidgetSettings>;
+  setEnabled: (enabled: boolean) => void;
+};
+
+export function DateTimeWidgetContextMenu({
+  changeDateTimeWidgetSetting,
+  dateTimeWidget,
+  setEnabled
+}: DateTimeWidgetContextMenuProps) {
+  const settings = dateTimeWidget.settings;
+
+  return (
+    <>
+      <header className="widget-context-header">
+        <span>Widget</span>
+        <strong>Date & Time</strong>
+      </header>
+      <label className="context-toggle-row">
+        <span>Enabled</span>
+        <input checked={dateTimeWidget.enabled} onChange={(event) => setEnabled(event.target.checked)} type="checkbox" />
+      </label>
+
+      <label>
+        <span>Clock mode</span>
+        <select
+          value={settings.clockMode}
+          onChange={(event) => changeDateTimeWidgetSetting("clockMode", event.target.value as DateTimeClockMode)}
+        >
+          <option value="digital">Digital</option>
+          <option value="percentageComplete">Percentage complete</option>
+          <option value="verticalClock">Vertical clock</option>
+        </select>
+      </label>
+      <label>
+        <span>Time format</span>
+        <select
+          value={settings.timeFormat}
+          onChange={(event) => changeDateTimeWidgetSetting("timeFormat", event.target.value as DateTimeFormat)}
+        >
+          <option value="twentyFourHour">24 hour</option>
+          <option value="twelveHour">12 hour</option>
+        </select>
+      </label>
+      <label className="context-toggle-row">
+        <span>Seconds</span>
+        <input
+          checked={settings.showSeconds}
+          onChange={(event) => changeDateTimeWidgetSetting("showSeconds", event.target.checked)}
+          type="checkbox"
+        />
+      </label>
+      <label className="context-toggle-row">
+        <span>Leading zero</span>
+        <input
+          checked={settings.padHour}
+          onChange={(event) => changeDateTimeWidgetSetting("padHour", event.target.checked)}
+          type="checkbox"
+        />
+      </label>
+
+      <label>
+        <span>Date mode</span>
+        <select
+          value={settings.dateMode}
+          onChange={(event) => changeDateTimeWidgetSetting("dateMode", event.target.value as DateTimeDateMode)}
+        >
+          <option value="hidden">Hidden</option>
+          <option value="long">Long</option>
+          <option value="short">Short</option>
+        </select>
+      </label>
+      <label>
+        <span>Date order</span>
+        <select
+          value={settings.dateOrder}
+          onChange={(event) => changeDateTimeWidgetSetting("dateOrder", event.target.value as DateTimeDateOrder)}
+        >
+          <option value="DMY">Day month year</option>
+          <option value="MDY">Month day year</option>
+          <option value="YMD">Year month day</option>
+        </select>
+      </label>
+      {settings.dateMode === "short" ? (
+        <label>
+          <span>Separator</span>
+          <select
+            value={settings.shortSeparator}
+            onChange={(event) => changeDateTimeWidgetSetting("shortSeparator", event.target.value as DateTimeShortSeparator)}
+          >
+            <option value="dash">Dash</option>
+            <option value="dots">Dots</option>
+            <option value="gaps">Spaces</option>
+            <option value="slashes">Slashes</option>
+          </select>
+        </label>
+      ) : null}
+      <label className="context-toggle-row">
+        <span>Weekday</span>
+        <input
+          checked={settings.showWeekday}
+          onChange={(event) => changeDateTimeWidgetSetting("showWeekday", event.target.checked)}
+          type="checkbox"
+        />
+      </label>
+      <label className="context-toggle-row">
+        <span>Ordinal day</span>
+        <input
+          checked={settings.showOrdinalDay}
+          onChange={(event) => changeDateTimeWidgetSetting("showOrdinalDay", event.target.checked)}
+          type="checkbox"
+        />
+      </label>
+      <label className="context-toggle-row">
+        <span>Week number</span>
+        <input
+          checked={settings.showWeekNumber}
+          onChange={(event) => changeDateTimeWidgetSetting("showWeekNumber", event.target.checked)}
+          type="checkbox"
+        />
+      </label>
+      <label className="context-toggle-row">
+        <span>Pad date</span>
+        <input
+          checked={settings.padDate}
+          onChange={(event) => changeDateTimeWidgetSetting("padDate", event.target.checked)}
+          type="checkbox"
+        />
+      </label>
+
+      <WidgetVisualControls visual={settings.visual} onChange={(visual) => changeDateTimeWidgetSetting("visual", visual)} />
+    </>
+  );
+}

--- a/src/ui/widgets/date-time/date-time-widget.css
+++ b/src/ui/widgets/date-time/date-time-widget.css
@@ -1,0 +1,117 @@
+.date-time-widget {
+  container-type: inline-size;
+  display: grid;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  align-content: center;
+  gap: clamp(8px, 5%, 14px);
+  color: var(--theme-text, #f8fafc);
+}
+
+.date-time-digital {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  gap: 10px;
+  padding-inline-end: 0.16em;
+}
+
+.date-time-digital strong {
+  display: inline-block;
+  color: #ffffff;
+  font-size: clamp(36px, 12vw, 78px);
+  font-weight: 950;
+  letter-spacing: -0.06em;
+  line-height: 0.92;
+  padding-inline-end: 0.08em;
+  white-space: nowrap;
+}
+
+.date-time-digital strong span {
+  color: var(--theme-accent, #7dd3fc);
+  margin: 0 0.03em;
+}
+
+.date-time-digital > span,
+.date-time-vertical > span {
+  color: var(--theme-muted-text, rgba(226, 232, 240, 0.78));
+  font-size: clamp(12px, 2vw, 16px);
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.date-time-date-group {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.date-time-date-group span {
+  overflow: hidden;
+  color: var(--theme-muted-text, rgba(226, 232, 240, 0.82));
+  font-size: clamp(13px, 2.2vw, 18px);
+  font-weight: 850;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.date-time-date-group small {
+  color: var(--theme-muted-text, rgba(226, 232, 240, 0.62));
+  font-size: 12px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.date-time-percentage {
+  display: grid;
+  gap: 4px;
+}
+
+.date-time-percentage strong {
+  color: #ffffff;
+  font-size: clamp(42px, 13vw, 86px);
+  font-weight: 950;
+  letter-spacing: -0.08em;
+  line-height: 0.92;
+}
+
+.date-time-percentage span {
+  color: var(--theme-muted-text, rgba(226, 232, 240, 0.78));
+  font-size: clamp(12px, 2vw, 16px);
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.date-time-vertical {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  align-items: center;
+  justify-content: start;
+  gap: clamp(8px, 4%, 14px);
+}
+
+.date-time-vertical strong {
+  display: grid;
+  min-width: 0;
+  max-width: 100%;
+  place-items: center;
+  overflow: hidden;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  font-size: clamp(24px, 26cqw, 58px);
+  font-weight: 950;
+  letter-spacing: -0.03em;
+  line-height: 1;
+  padding: 8px 6px;
+  text-align: center;
+}
+
+.date-time-vertical > span {
+  align-self: end;
+  padding-bottom: 8px;
+}

--- a/src/ui/widgets/date-time/index.ts
+++ b/src/ui/widgets/date-time/index.ts
@@ -1,0 +1,2 @@
+export { DateTimeWidget } from "./DateTimeWidget";
+export { DateTimeWidgetContextMenu } from "./DateTimeWidgetContextMenu";

--- a/src/ui/widgets/search/SearchWidget.tsx
+++ b/src/ui/widgets/search/SearchWidget.tsx
@@ -1,7 +1,8 @@
-import type { FormEvent, MouseEvent } from "react";
+import type { CSSProperties, FormEvent, MouseEvent } from "react";
 import { brandIcons, type BrandIcon } from "../../../domain/brandIcons";
 import { buildSearchUrl, searchVerticals, type SearchProviderId, type SearchVerticalId } from "../../../domain/tabState";
 import type { SearchWidgetSettings } from "../../../domain/canvas";
+import { getWidgetSurfaceStyle } from "../widgetSurface";
 
 type SearchWidgetProps = {
   activeProvider: { label: string };
@@ -24,6 +25,8 @@ const providerMarks: Record<SearchProviderId, ProviderMark> = {
 };
 
 export function SearchWidget({ activeProvider, changeSearchVertical, query, setQuery, settings }: SearchWidgetProps) {
+  const surfaceStyle = getSearchSurfaceStyle(settings);
+
   function submitSearch(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
@@ -41,7 +44,7 @@ export function SearchWidget({ activeProvider, changeSearchVertical, query, setQ
   }
 
   return (
-    <section className="search-panel">
+    <section className="search-panel widget-surface" style={surfaceStyle}>
       {settings.showProviderTabs ? (
         <div className="search-tabs" role="tablist" aria-label={`${activeProvider.label} search category`}>
           {Object.entries(searchVerticals).map(([id, vertical]) => (
@@ -71,6 +74,14 @@ export function SearchWidget({ activeProvider, changeSearchVertical, query, setQ
       </form>
     </section>
   );
+}
+
+function getSearchSurfaceStyle(settings: SearchWidgetSettings) {
+  return {
+    ...getWidgetSurfaceStyle(settings),
+    "--widget-padding": "clamp(10px, 3%, 16px)",
+    "--widget-radius": "28px"
+  } as CSSProperties;
 }
 
 function ProviderBrandMark({ providerId, providerLabel }: { providerId: SearchProviderId; providerLabel: string }) {

--- a/src/ui/widgets/search/SearchWidgetContextMenu.tsx
+++ b/src/ui/widgets/search/SearchWidgetContextMenu.tsx
@@ -1,7 +1,7 @@
 import { searchProviders, type SearchProviderId } from "../../../domain/tabState";
 import type { SearchWidgetSettings } from "../../../domain/canvas";
 import type { WidgetState } from "../../../domain/canvas";
-import { RangeRow } from "../WidgetContextMenuControls";
+import { RangeRow, WidgetVisualControls } from "../WidgetContextMenuControls";
 
 type SearchWidgetContextMenuProps = {
   changeSearchWidgetSetting: <K extends keyof SearchWidgetSettings>(key: K, value: SearchWidgetSettings[K]) => void;
@@ -54,13 +54,14 @@ export function SearchWidgetContextMenu({
         />
       </label>
       <RangeRow
-        label="Opacity"
+        label="Input opacity"
         max={100}
         min={0}
         onChange={(value) => changeSearchWidgetSetting("opacity", value)}
         suffix="%"
         value={searchWidget.settings.opacity}
       />
+      <WidgetVisualControls visual={searchWidget.settings.visual} onChange={(visual) => changeSearchWidgetSetting("visual", visual)} />
       <RangeRow
         label="Roundness"
         max={100}

--- a/src/ui/widgets/search/search-widget.css
+++ b/src/ui/widgets/search/search-widget.css
@@ -1,6 +1,7 @@
 .search-panel {
+  box-sizing: border-box;
   width: min(var(--search-box-size), 100%);
-  height: 100%;
+  min-height: 100%;
 }
 
 .search-tabs {

--- a/src/ui/widgets/shortcut-grid/ShortcutGrid.tsx
+++ b/src/ui/widgets/shortcut-grid/ShortcutGrid.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { createPortal } from "react-dom";
 import { useReducedMotion } from "motion/react";
 import { brandIcons } from "../../../domain/brandIcons";
 import type { DropAction } from "../../../domain/dropActions";
@@ -12,6 +13,7 @@ import { useGridDragSession } from "./useGridDragSession";
 
 type ShortcutGridProps = {
   activeShortcutPageIndex: number;
+  dragOverlayStyle: React.CSSProperties;
   dispatchDropAction: (action: DropAction) => void;
   gridRef: React.RefObject<HTMLElement | null>;
   outgoingDragSource: DragSource | null;
@@ -30,6 +32,7 @@ type ShortcutGridProps = {
 
 export function ShortcutGrid({
   activeShortcutPageIndex,
+  dragOverlayStyle,
   dispatchDropAction,
   gridRef,
   outgoingDragSource,
@@ -218,10 +221,12 @@ export function ShortcutGrid({
         ) : null}
       </nav>
 
-      {dragSession.dragOverlay && Number.isFinite(dragSession.dragOverlay.x) && Number.isFinite(dragSession.dragOverlay.y) && (
+      {dragSession.dragOverlay && Number.isFinite(dragSession.dragOverlay.x) && Number.isFinite(dragSession.dragOverlay.y)
+        ? createPortal(
         <div
           className={["drag-overlay-tile", isCombinePreview ? "merge-active" : ""].filter(Boolean).join(" ")}
           style={{
+            ...dragOverlayStyle,
             position: 'fixed',
             left: dragSession.dragOverlay.x - 40,
             top: dragSession.dragOverlay.y - 40,
@@ -235,8 +240,10 @@ export function ShortcutGrid({
               +
             </span>
           ) : null}
-        </div>
-      )}
+        </div>,
+        document.body
+      )
+        : null}
     </>
   );
 }

--- a/src/ui/widgets/shortcut-grid/ShortcutGridWidget.tsx
+++ b/src/ui/widgets/shortcut-grid/ShortcutGridWidget.tsx
@@ -6,6 +6,7 @@ import type { DragSource } from "../../drag/dragModel";
 import { deriveShortcutGridWidgetModel } from "./shortcutPageModel";
 import { useShortcutGridMetrics } from "./useShortcutGridMetrics";
 import { ShortcutGrid } from "./ShortcutGrid";
+import { getWidgetSurfaceStyle } from "../widgetSurface";
 
 type CanvasMetrics = {
   cellWidth: number;
@@ -69,14 +70,25 @@ export function ShortcutGridWidget({
     settings.showLabels,
     activeShortcutPageIndex
   );
+  const iconSize = `${Math.max(18, Math.min(maxFittedIconSize, (86 * gridLayout.iconSize) / 100))}px`;
+  const labelFontSize = `${fittedLabelSize}px`;
+  const tileGap = `${fittedTileGap}px`;
   const layoutStyle = {
-    "--icon-size": `${Math.max(18, Math.min(maxFittedIconSize, (86 * gridLayout.iconSize) / 100))}px`,
+    "--icon-size": iconSize,
     "--grid-column-gap": `${(34 * gridLayout.columnSpacing) / 100}px`,
     "--grid-row-gap": `${(34 * gridLayout.lineSpacing) / 100}px`,
     "--grid-columns": `${gridLayout.columns}`,
     "--grid-rows": `${gridLayout.rows}`,
-    "--quick-link-label-font-size": `${fittedLabelSize}px`,
-    "--quick-link-tile-gap": `${fittedTileGap}px`
+    "--quick-link-label-font-size": labelFontSize,
+    "--quick-link-tile-gap": tileGap,
+    ...getWidgetSurfaceStyle(settings),
+    "--widget-padding": "18px 18px 8px",
+    "--widget-radius": "28px"
+  } as CSSProperties;
+  const dragOverlayStyle = {
+    "--icon-size": iconSize,
+    "--quick-link-label-font-size": labelFontSize,
+    "--quick-link-tile-gap": tileGap
   } as CSSProperties;
 
   useEffect(() => {
@@ -117,9 +129,10 @@ export function ShortcutGridWidget({
   }
 
   return (
-    <div className="shortcut-grid-widget" onWheel={handleShortcutWheel} style={layoutStyle}>
+    <div className="shortcut-grid-widget widget-surface" onWheel={handleShortcutWheel} style={layoutStyle}>
       <ShortcutGrid
         activeShortcutPageIndex={activeShortcutPageIndex}
+        dragOverlayStyle={dragOverlayStyle}
         dispatchDropAction={dispatchDropAction}
         gridRef={gridRef}
         outgoingDragSource={isCanvasEditMode ? null : outgoingDragSource}

--- a/src/ui/widgets/shortcut-grid/ShortcutGridWidgetContextMenu.tsx
+++ b/src/ui/widgets/shortcut-grid/ShortcutGridWidgetContextMenu.tsx
@@ -1,5 +1,5 @@
 import type { ShortcutGridWidgetSettings, WidgetState } from "../../../domain/canvas";
-import { RangeRow } from "../WidgetContextMenuControls";
+import { RangeRow, WidgetVisualControls } from "../WidgetContextMenuControls";
 
 type ShortcutGridWidgetContextMenuProps = {
   changeShortcutGridWidgetSetting: <K extends keyof ShortcutGridWidgetSettings>(
@@ -48,6 +48,10 @@ export function ShortcutGridWidgetContextMenu({
         onChange={(value) => changeShortcutGridWidgetSetting("lineSpacing", value)}
         suffix="%"
         value={shortcutGridWidget.settings.lineSpacing}
+      />
+      <WidgetVisualControls
+        visual={shortcutGridWidget.settings.visual}
+        onChange={(visual) => changeShortcutGridWidgetSetting("visual", visual)}
       />
       <label className="context-toggle-row">
         <span>Labels</span>

--- a/src/ui/widgets/shortcut-grid/shortcut-grid-widget.css
+++ b/src/ui/widgets/shortcut-grid/shortcut-grid-widget.css
@@ -18,7 +18,6 @@
 .shortcut-grid-widget {
   width: 100%;
   height: 100%;
-  padding: 18px 18px 8px;
 }
 
 .shortcut-grid-widget .quick-link-grid {

--- a/src/ui/widgets/weather/WeatherWidget.tsx
+++ b/src/ui/widgets/weather/WeatherWidget.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useState, type CSSProperties } from "react";
+import {
+  AlertTriangle,
+  Cloud,
+  CloudFog,
+  CloudLightning,
+  CloudRain,
+  CloudSnow,
+  Droplets,
+  LoaderCircle,
+  MapPin,
+  Moon,
+  Sun,
+  Thermometer,
+  Umbrella,
+  Wind,
+  type LucideIcon
+} from "lucide-react";
+import type { WeatherWidgetSettings } from "../../../domain/canvas";
+import { getWidgetSurfaceStyle } from "../widgetSurface";
+import { fetchWeatherSnapshot, type WeatherSnapshot } from "./weatherService";
+
+type WeatherWidgetProps = {
+  settings: WeatherWidgetSettings;
+};
+
+type WeatherStatus =
+  | { type: "loading" }
+  | { type: "ready"; snapshot: WeatherSnapshot }
+  | { type: "error"; message: string };
+
+export function WeatherWidget({ settings }: WeatherWidgetProps) {
+  const [status, setStatus] = useState<WeatherStatus>({ type: "loading" });
+  const surfaceStyle = getWeatherSurfaceStyle(settings);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setStatus({ type: "loading" });
+
+    fetchWeatherSnapshot(settings, controller.signal)
+      .then((snapshot) => setStatus({ type: "ready", snapshot }))
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        setStatus({ type: "error", message: error instanceof Error ? error.message : "Weather unavailable." });
+      });
+
+    return () => controller.abort();
+  }, [
+    settings.latitude,
+    settings.longitude,
+    settings.units,
+    settings.locationName,
+    settings.refreshMinutes,
+    settings.displayMode
+  ]);
+
+  if (status.type === "loading") {
+    return (
+      <section className="weather-widget widget-surface weather-widget-loading" aria-label="Weather loading" style={surfaceStyle}>
+        <LoaderCircle aria-hidden="true" className="weather-spin" />
+        <span>Loading weather</span>
+      </section>
+    );
+  }
+
+  if (status.type === "error") {
+    return (
+      <section className="weather-widget widget-surface weather-widget-error" aria-label="Weather error" style={surfaceStyle}>
+        <AlertTriangle aria-hidden="true" />
+        <div>
+          <strong>Weather unavailable</strong>
+          <span>{status.message}</span>
+        </div>
+      </section>
+    );
+  }
+
+  return <WeatherSnapshotView settings={settings} snapshot={status.snapshot} surfaceStyle={surfaceStyle} />;
+}
+
+function WeatherSnapshotView({
+  settings,
+  snapshot,
+  surfaceStyle
+}: {
+  settings: WeatherWidgetSettings;
+  snapshot: WeatherSnapshot;
+  surfaceStyle: CSSProperties;
+}) {
+  const Icon = getWeatherIcon(snapshot);
+  const mode = settings.displayMode;
+  const showExpanded = mode === "expanded";
+
+  return (
+    <section className={`weather-widget widget-surface weather-widget-${mode}`} aria-label={`Weather for ${snapshot.locationName}`} style={surfaceStyle}>
+      <div className="weather-primary">
+        <span className={`weather-icon weather-tone-${snapshot.condition.tone}`} aria-hidden="true">
+          <Icon />
+        </span>
+        <div className="weather-temp-group">
+          <strong>{formatTemperature(snapshot.temperature, snapshot.units.temperature)}</strong>
+          <span>{snapshot.condition.label}</span>
+        </div>
+      </div>
+
+      {mode !== "compact" ? (
+        <div className="weather-secondary">
+          <span className="weather-location"><MapPin aria-hidden="true" />{snapshot.locationName}</span>
+          {settings.showFeelsLike ? (
+            <span><Thermometer aria-hidden="true" />Feels {formatTemperature(snapshot.apparentTemperature, snapshot.units.temperature)}</span>
+          ) : null}
+        </div>
+      ) : (
+        <span className="weather-compact-location">{snapshot.locationName}</span>
+      )}
+
+      {showExpanded ? (
+        <div className="weather-details">
+          {settings.showHumidity ? <WeatherDetail icon={Droplets} label="Humidity" value={`${snapshot.humidity}%`} /> : null}
+          {settings.showWind ? (
+            <WeatherDetail icon={Wind} label="Wind" value={`${snapshot.windSpeed} ${snapshot.units.windSpeed}`} />
+          ) : null}
+          {settings.showPrecipitation ? (
+            <WeatherDetail icon={Umbrella} label="Rain" value={`${snapshot.precipitation} ${snapshot.units.precipitation}`} />
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function getWeatherSurfaceStyle(settings: WeatherWidgetSettings) {
+  return {
+    ...getWidgetSurfaceStyle(settings),
+    "--widget-padding": "clamp(12px, 8%, 18px)",
+    "--widget-radius": "24px"
+  } as CSSProperties;
+}
+
+function WeatherDetail({ icon: Icon, label, value }: { icon: LucideIcon; label: string; value: string }) {
+  return (
+    <span className="weather-detail">
+      <Icon aria-hidden="true" />
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </span>
+  );
+}
+
+function getWeatherIcon(snapshot: WeatherSnapshot): LucideIcon {
+  if (snapshot.condition.tone === "clear") {
+    return snapshot.isDay ? Sun : Moon;
+  }
+
+  const icons: Record<WeatherSnapshot["condition"]["tone"], LucideIcon> = {
+    clear: Sun,
+    cloud: Cloud,
+    fog: CloudFog,
+    rain: CloudRain,
+    snow: CloudSnow,
+    storm: CloudLightning
+  };
+
+  return icons[snapshot.condition.tone];
+}
+
+function formatTemperature(value: number, unit: string) {
+  return `${value}${unit}`;
+}

--- a/src/ui/widgets/weather/WeatherWidgetContextMenu.tsx
+++ b/src/ui/widgets/weather/WeatherWidgetContextMenu.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useState, type FormEvent } from "react";
+import type { WeatherDisplayMode, WeatherUnits, WeatherWidgetSettings, WidgetState } from "../../../domain/canvas";
+import { RangeRow, WidgetVisualControls } from "../WidgetContextMenuControls";
+import { resolveWeatherLocation } from "./weatherService";
+
+type WeatherWidgetContextMenuProps = {
+  changeWeatherWidgetSetting: <K extends keyof WeatherWidgetSettings>(key: K, value: WeatherWidgetSettings[K]) => void;
+  setEnabled: (enabled: boolean) => void;
+  weatherWidget: WidgetState<WeatherWidgetSettings>;
+};
+
+export function WeatherWidgetContextMenu({
+  changeWeatherWidgetSetting,
+  setEnabled,
+  weatherWidget
+}: WeatherWidgetContextMenuProps) {
+  const [locationDraft, setLocationDraft] = useState(weatherWidget.settings.locationName);
+  const [locationStatus, setLocationStatus] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLocationDraft(weatherWidget.settings.locationName);
+  }, [weatherWidget.settings.locationName]);
+
+  async function saveLocation(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setLocationStatus("Searching...");
+
+    try {
+      const result = await resolveWeatherLocation(locationDraft);
+      changeWeatherWidgetSetting("locationName", result.name);
+      changeWeatherWidgetSetting("latitude", result.latitude);
+      changeWeatherWidgetSetting("longitude", result.longitude);
+      setLocationDraft(result.name);
+      setLocationStatus("Location updated");
+    } catch (error) {
+      setLocationStatus(error instanceof Error ? error.message : "Location lookup failed.");
+    }
+  }
+
+  return (
+    <>
+      <header className="widget-context-header">
+        <span>Widget</span>
+        <strong>Weather</strong>
+      </header>
+      <label className="context-toggle-row">
+        <span>Enabled</span>
+        <input checked={weatherWidget.enabled} onChange={(event) => setEnabled(event.target.checked)} type="checkbox" />
+      </label>
+
+      <form className="weather-context-location" onSubmit={saveLocation}>
+        <label>
+          <span>Location</span>
+          <input
+            onChange={(event) => setLocationDraft(event.target.value)}
+            placeholder="London"
+            type="text"
+            value={locationDraft}
+          />
+        </label>
+        <button type="submit">Find location</button>
+        {locationStatus ? <p>{locationStatus}</p> : null}
+      </form>
+
+      <label>
+        <span>Units</span>
+        <select
+          value={weatherWidget.settings.units}
+          onChange={(event) => changeWeatherWidgetSetting("units", event.target.value as WeatherUnits)}
+        >
+          <option value="celsius">Celsius</option>
+          <option value="fahrenheit">Fahrenheit</option>
+        </select>
+      </label>
+
+      <label>
+        <span>Display</span>
+        <select
+          value={weatherWidget.settings.displayMode}
+          onChange={(event) => changeWeatherWidgetSetting("displayMode", event.target.value as WeatherDisplayMode)}
+        >
+          <option value="compact">Compact</option>
+          <option value="standard">Standard</option>
+          <option value="expanded">Expanded</option>
+        </select>
+      </label>
+
+      <RangeRow
+        label="Refresh"
+        max={120}
+        min={5}
+        onChange={(value) => changeWeatherWidgetSetting("refreshMinutes", value)}
+        suffix=" min"
+        value={weatherWidget.settings.refreshMinutes}
+      />
+
+      <WidgetVisualControls visual={weatherWidget.settings.visual} onChange={(visual) => changeWeatherWidgetSetting("visual", visual)} />
+
+      <label className="context-toggle-row">
+        <span>Feels like</span>
+        <input
+          checked={weatherWidget.settings.showFeelsLike}
+          onChange={(event) => changeWeatherWidgetSetting("showFeelsLike", event.target.checked)}
+          type="checkbox"
+        />
+      </label>
+      <label className="context-toggle-row">
+        <span>Humidity</span>
+        <input
+          checked={weatherWidget.settings.showHumidity}
+          onChange={(event) => changeWeatherWidgetSetting("showHumidity", event.target.checked)}
+          type="checkbox"
+        />
+      </label>
+      <label className="context-toggle-row">
+        <span>Wind</span>
+        <input
+          checked={weatherWidget.settings.showWind}
+          onChange={(event) => changeWeatherWidgetSetting("showWind", event.target.checked)}
+          type="checkbox"
+        />
+      </label>
+      <label className="context-toggle-row">
+        <span>Precipitation</span>
+        <input
+          checked={weatherWidget.settings.showPrecipitation}
+          onChange={(event) => changeWeatherWidgetSetting("showPrecipitation", event.target.checked)}
+          type="checkbox"
+        />
+      </label>
+    </>
+  );
+}

--- a/src/ui/widgets/weather/index.ts
+++ b/src/ui/widgets/weather/index.ts
@@ -1,0 +1,2 @@
+export { WeatherWidget } from "./WeatherWidget";
+export { WeatherWidgetContextMenu } from "./WeatherWidgetContextMenu";

--- a/src/ui/widgets/weather/weather-widget.css
+++ b/src/ui/widgets/weather/weather-widget.css
@@ -1,0 +1,203 @@
+.weather-widget {
+  display: grid;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  align-content: center;
+  gap: 10px;
+  color: var(--theme-text, #f8fafc);
+}
+
+.weather-primary {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 12px;
+}
+
+.weather-icon {
+  display: grid;
+  width: clamp(42px, 28%, 68px);
+  aspect-ratio: 1;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.12);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.16);
+}
+
+.weather-icon svg {
+  width: 58%;
+  height: 58%;
+}
+
+.weather-tone-clear { color: #fde68a; }
+.weather-tone-cloud { color: #bae6fd; }
+.weather-tone-rain { color: #93c5fd; }
+.weather-tone-storm { color: #c4b5fd; }
+.weather-tone-snow { color: #e0f2fe; }
+.weather-tone-fog { color: #cbd5e1; }
+
+.weather-temp-group {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.weather-temp-group strong {
+  color: #ffffff;
+  font-size: clamp(28px, 8vw, 46px);
+  font-weight: 950;
+  letter-spacing: -0.07em;
+  line-height: 0.95;
+}
+
+.weather-temp-group span,
+.weather-compact-location,
+.weather-secondary span,
+.weather-detail span {
+  overflow: hidden;
+  color: var(--theme-muted-text, rgba(226, 232, 240, 0.78));
+  font-size: clamp(11px, 1.4vw, 13px);
+  font-weight: 800;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.weather-secondary {
+  display: grid;
+  gap: 6px;
+}
+
+.weather-secondary span,
+.weather-detail {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+}
+
+.weather-secondary svg,
+.weather-detail svg {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 auto;
+  color: var(--theme-accent, #7dd3fc);
+}
+
+.weather-details {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 7px;
+}
+
+.weather-detail {
+  display: grid;
+  min-width: 0;
+  justify-items: start;
+  gap: 4px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.08);
+  padding: 8px;
+}
+
+.weather-detail strong {
+  overflow: hidden;
+  max-width: 100%;
+  color: #ffffff;
+  font-size: 12px;
+  font-weight: 950;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.weather-widget-compact {
+  align-content: center;
+  gap: 5px;
+}
+
+.weather-widget-compact .weather-primary {
+  justify-content: center;
+}
+
+.weather-compact-location {
+  text-align: center;
+}
+
+.weather-widget-loading,
+.weather-widget-error {
+  grid-template-columns: auto 1fr;
+  align-content: center;
+  align-items: center;
+}
+
+.weather-widget-loading svg,
+.weather-widget-error > svg {
+  width: 28px;
+  height: 28px;
+  color: var(--theme-accent, #7dd3fc);
+}
+
+.weather-widget-loading span,
+.weather-widget-error span {
+  color: var(--theme-muted-text, rgba(226, 232, 240, 0.8));
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.weather-widget-error strong {
+  display: block;
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 950;
+}
+
+.weather-spin {
+  animation: weather-spin 0.9s linear infinite;
+}
+
+.weather-context-location {
+  display: grid;
+  gap: 8px;
+  border-radius: 16px;
+  background: var(--theme-settings-card-bg, rgba(255, 255, 255, 0.06));
+  padding: 10px 12px;
+}
+
+.weather-context-location label {
+  padding: 0;
+  background: transparent;
+}
+
+.weather-context-location input {
+  width: 100%;
+  height: 36px;
+  border: 1px solid var(--theme-border, rgba(255, 255, 255, 0.16));
+  border-radius: 12px;
+  background: var(--theme-input-bg, rgba(15, 23, 42, 0.92));
+  color: var(--theme-input-text, #f8fafc);
+  padding: 0 10px;
+}
+
+.weather-context-location button {
+  height: 36px;
+  border: 0;
+  border-radius: 12px;
+  background: var(--theme-accent, #7dd3fc);
+  color: #082f49;
+  cursor: pointer;
+  font-weight: 950;
+}
+
+.weather-context-location p {
+  margin: 0;
+  color: var(--theme-muted-text, rgba(226, 232, 240, 0.78));
+  font-size: 12px;
+  font-weight: 800;
+}
+
+@keyframes weather-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/ui/widgets/weather/weatherService.ts
+++ b/src/ui/widgets/weather/weatherService.ts
@@ -1,0 +1,186 @@
+import type { WeatherWidgetSettings } from "../../../domain/canvas";
+
+export type WeatherCondition = {
+  code: number;
+  label: string;
+  tone: "clear" | "cloud" | "rain" | "storm" | "snow" | "fog";
+};
+
+export type WeatherLocationResult = {
+  name: string;
+  latitude: number;
+  longitude: number;
+};
+
+export type WeatherSnapshot = {
+  locationName: string;
+  temperature: number;
+  apparentTemperature: number;
+  humidity: number;
+  precipitation: number;
+  windSpeed: number;
+  windDirection: number;
+  isDay: boolean;
+  units: {
+    temperature: string;
+    precipitation: string;
+    windSpeed: string;
+  };
+  condition: WeatherCondition;
+  fetchedAt: number;
+};
+
+type OpenMeteoGeocodingResponse = {
+  results?: Array<{
+    name: string;
+    admin1?: string;
+    country?: string;
+    latitude: number;
+    longitude: number;
+  }>;
+};
+
+type OpenMeteoForecastResponse = {
+  current?: {
+    temperature_2m?: number;
+    apparent_temperature?: number;
+    relative_humidity_2m?: number;
+    precipitation?: number;
+    weather_code?: number;
+    wind_speed_10m?: number;
+    wind_direction_10m?: number;
+    is_day?: number;
+  };
+  current_units?: {
+    temperature_2m?: string;
+    precipitation?: string;
+    wind_speed_10m?: string;
+  };
+};
+
+const cache = new Map<string, WeatherSnapshot>();
+
+export async function resolveWeatherLocation(query: string, signal?: AbortSignal): Promise<WeatherLocationResult> {
+  const trimmedQuery = query.trim();
+  if (!trimmedQuery) {
+    throw new Error("Enter a location.");
+  }
+
+  const params = new URLSearchParams({ name: trimmedQuery, count: "1", language: "en", format: "json" });
+  const response = await fetch(`https://geocoding-api.open-meteo.com/v1/search?${params.toString()}`, { signal });
+  if (!response.ok) {
+    throw new Error("Location lookup failed.");
+  }
+
+  const data = (await response.json()) as OpenMeteoGeocodingResponse;
+  const result = data.results?.[0];
+  if (!result) {
+    throw new Error("Location not found.");
+  }
+
+  return {
+    name: [result.name, result.admin1, result.country].filter(Boolean).join(", "),
+    latitude: result.latitude,
+    longitude: result.longitude
+  };
+}
+
+export async function fetchWeatherSnapshot(settings: WeatherWidgetSettings, signal?: AbortSignal): Promise<WeatherSnapshot> {
+  const cacheKey = `${settings.latitude.toFixed(3)}:${settings.longitude.toFixed(3)}:${settings.units}`;
+  const cached = cache.get(cacheKey);
+  if (cached && Date.now() - cached.fetchedAt < settings.refreshMinutes * 60_000) {
+    return cached;
+  }
+
+  const params = new URLSearchParams({
+    latitude: String(settings.latitude),
+    longitude: String(settings.longitude),
+    current: [
+      "temperature_2m",
+      "apparent_temperature",
+      "relative_humidity_2m",
+      "precipitation",
+      "weather_code",
+      "wind_speed_10m",
+      "wind_direction_10m",
+      "is_day"
+    ].join(","),
+    timezone: "auto"
+  });
+
+  if (settings.units === "fahrenheit") {
+    params.set("temperature_unit", "fahrenheit");
+  }
+
+  const response = await fetch(`https://api.open-meteo.com/v1/forecast?${params.toString()}`, { signal });
+  if (!response.ok) {
+    throw new Error("Weather fetch failed.");
+  }
+
+  const data = (await response.json()) as OpenMeteoForecastResponse;
+  if (!data.current) {
+    throw new Error("Weather data unavailable.");
+  }
+
+  const snapshot: WeatherSnapshot = {
+    locationName: settings.locationName,
+    temperature: roundWeatherValue(data.current.temperature_2m),
+    apparentTemperature: roundWeatherValue(data.current.apparent_temperature),
+    humidity: roundWeatherValue(data.current.relative_humidity_2m),
+    precipitation: roundWeatherValue(data.current.precipitation, 1),
+    windSpeed: roundWeatherValue(data.current.wind_speed_10m),
+    windDirection: roundWeatherValue(data.current.wind_direction_10m),
+    isDay: data.current.is_day !== 0,
+    units: {
+      temperature: data.current_units?.temperature_2m ?? (settings.units === "fahrenheit" ? "°F" : "°C"),
+      precipitation: data.current_units?.precipitation ?? "mm",
+      windSpeed: data.current_units?.wind_speed_10m ?? "km/h"
+    },
+    condition: describeWeatherCode(data.current.weather_code ?? 0),
+    fetchedAt: Date.now()
+  };
+
+  cache.set(cacheKey, snapshot);
+  return snapshot;
+}
+
+export function describeWeatherCode(code: number): WeatherCondition {
+  if (code === 0) {
+    return { code, label: "Clear sky", tone: "clear" };
+  }
+
+  if ([1, 2].includes(code)) {
+    return { code, label: "Partly cloudy", tone: "cloud" };
+  }
+
+  if (code === 3) {
+    return { code, label: "Overcast", tone: "cloud" };
+  }
+
+  if ([45, 48].includes(code)) {
+    return { code, label: "Fog", tone: "fog" };
+  }
+
+  if ([51, 53, 55, 56, 57, 61, 63, 65, 66, 67, 80, 81, 82].includes(code)) {
+    return { code, label: "Rain", tone: "rain" };
+  }
+
+  if ([71, 73, 75, 77, 85, 86].includes(code)) {
+    return { code, label: "Snow", tone: "snow" };
+  }
+
+  if ([95, 96, 99].includes(code)) {
+    return { code, label: "Thunderstorm", tone: "storm" };
+  }
+
+  return { code, label: "Cloudy", tone: "cloud" };
+}
+
+function roundWeatherValue(value: number | undefined, digits = 0) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return 0;
+  }
+
+  const multiplier = 10 ** digits;
+  return Math.round(value * multiplier) / multiplier;
+}

--- a/src/ui/widgets/widget-surface.css
+++ b/src/ui/widgets/widget-surface.css
@@ -1,0 +1,13 @@
+.widget-surface {
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--widget-border-color, #ffffff) calc(var(--widget-border-opacity, 0) * 100%), transparent);
+  border-radius: var(--widget-radius, 24px);
+  background:
+    radial-gradient(circle at 18% 18%, rgba(125, 211, 252, var(--widget-bg-accent-opacity, 0)), transparent 34%),
+    linear-gradient(145deg, rgba(15, 23, 42, var(--widget-bg-opacity, 0)), rgba(30, 41, 59, calc(var(--widget-bg-opacity, 0) * 0.58)));
+  box-shadow:
+    0 18px 44px rgba(0, 0, 0, var(--widget-shadow-opacity, 0)),
+    inset 0 1px 0 color-mix(in srgb, var(--widget-border-color, #ffffff) calc(var(--widget-border-opacity, 0) * 100%), transparent);
+  padding: var(--widget-padding, 0);
+  backdrop-filter: blur(calc(var(--widget-bg-opacity, 0) * 36px)) saturate(1.2);
+}

--- a/src/ui/widgets/widgetSurface.ts
+++ b/src/ui/widgets/widgetSurface.ts
@@ -1,0 +1,22 @@
+import type { CSSProperties } from "react";
+import type { WidgetVisualSettings } from "../../domain/canvas";
+
+export type TranslucentWidgetSurfaceSettings = {
+  visual: WidgetVisualSettings;
+};
+
+export function getWidgetSurfaceStyle(settings: TranslucentWidgetSurfaceSettings) {
+  const backgroundOpacity = settings.visual.backgroundOpacity / 100;
+  const borderOpacity = settings.visual.showBorder ? settings.visual.borderOpacity / 100 : backgroundOpacity * 0.42;
+
+  return {
+    "--widget-bg-opacity": `${backgroundOpacity}`,
+    "--widget-bg-accent-opacity": `${backgroundOpacity * 0.65}`,
+    "--widget-border-opacity": `${borderOpacity}`,
+    "--widget-shadow-opacity": `${(settings.visual.shadow / 60) * backgroundOpacity}`,
+    "--widget-radius": `${settings.visual.radius}px`,
+    "--widget-padding": `${settings.visual.padding}px`,
+    "--widget-bg-color": settings.visual.backgroundColor,
+    "--widget-border-color": settings.visual.borderColor
+  } as CSSProperties;
+}

--- a/src/ui/widgets/widgets.css
+++ b/src/ui/widgets/widgets.css
@@ -1,5 +1,8 @@
 @import "./widget-frame.css";
+@import "./widget-surface.css";
 @import "./WidgetContextMenu.css";
 @import "./search/search-widget.css";
 @import "./shortcut-grid/shortcut-grid-widget.css";
 @import "./shortcut-grid/shortcuts/shortcut-tiles.css";
+@import "./weather/weather-widget.css";
+@import "./date-time/date-time-widget.css";

--- a/tests/unit/domain/canvas.test.ts
+++ b/tests/unit/domain/canvas.test.ts
@@ -20,12 +20,16 @@ describe("canvas placement", () => {
   it("derives centered default Widget placements from Canvas size", () => {
     expect(deriveDefaultWidgetPlacements({ columns: 34, rows: 19 })).toEqual({
       search: { x: 11.5, y: 2, width: 11, height: 1, zIndex: 10 },
-      shortcutGrid: { x: 10.5, y: 5, width: 13, height: 7, zIndex: 5 }
+      shortcutGrid: { x: 10.5, y: 5, width: 13, height: 7, zIndex: 5 },
+      weather: { x: 0, y: 16, width: 5, height: 3, zIndex: 8 },
+      dateTime: { x: 0, y: 0, width: 7, height: 3, zIndex: 8 }
     });
 
     expect(deriveDefaultWidgetPlacements({ columns: 20, rows: 12 })).toEqual({
       search: { x: 4.5, y: 2, width: 11, height: 1, zIndex: 10 },
-      shortcutGrid: { x: 3.5, y: 5, width: 13, height: 6, zIndex: 5 }
+      shortcutGrid: { x: 3.5, y: 5, width: 13, height: 6, zIndex: 5 },
+      weather: { x: 0, y: 9, width: 5, height: 3, zIndex: 8 },
+      dateTime: { x: 0, y: 0, width: 7, height: 3, zIndex: 8 }
     });
   });
 
@@ -36,6 +40,12 @@ describe("canvas placement", () => {
 
     const customPlacement = { x: 2, y: 4, width: 11, height: 1, zIndex: 10 };
     expect(resolveResponsiveDefaultWidgetPlacement("search", customPlacement, { columns: 20, rows: 12 })).toBe(customPlacement);
+    expect(
+      resolveResponsiveDefaultWidgetPlacement("weather", { x: 29, y: 0, width: 5, height: 2, zIndex: 8 }, { columns: 20, rows: 12 })
+    ).toEqual({ x: 0, y: 9, width: 5, height: 3, zIndex: 8 });
+    expect(
+      resolveResponsiveDefaultWidgetPlacement("dateTime", { x: 0, y: 0, width: 7, height: 3, zIndex: 8 }, { columns: 20, rows: 12 })
+    ).toEqual({ x: 0, y: 0, width: 7, height: 3, zIndex: 8 });
   });
 
   it("keeps fractional placement while clamping inside the canvas", () => {

--- a/tests/unit/domain/tabState.test.ts
+++ b/tests/unit/domain/tabState.test.ts
@@ -217,6 +217,99 @@ describe("normalizeTabState", () => {
 
     expect(normalized.canvas.widgets.search.settings.searchVertical).toBe("web");
   });
+
+  it("backfills Weather Widget defaults for persisted Canvas state without weather", () => {
+    const { weather: _weather, ...widgetsWithoutWeather } = defaultTabState.canvas.widgets;
+    const normalized = normalizeTabState({
+      ...defaultTabState,
+      canvas: {
+        ...defaultTabState.canvas,
+        widgets: widgetsWithoutWeather
+      }
+    });
+
+    expect(normalized.canvas.widgets.weather.settings.locationName).toBe("London");
+    expect(normalized.canvas.widgets.weather.enabled).toBe(true);
+  });
+
+  it("backfills Date & Time Widget defaults for persisted Canvas state without dateTime", () => {
+    const { dateTime: _dateTime, ...widgetsWithoutDateTime } = defaultTabState.canvas.widgets;
+    const normalized = normalizeTabState({
+      ...defaultTabState,
+      canvas: {
+        ...defaultTabState.canvas,
+        widgets: widgetsWithoutDateTime
+      }
+    });
+
+    expect(normalized.canvas.widgets.dateTime.settings.clockMode).toBe("verticalClock");
+    expect(normalized.canvas.widgets.dateTime.settings.showSeconds).toBe(true);
+    expect(normalized.canvas.widgets.dateTime.settings.dateMode).toBe("long");
+  });
+
+  it("normalizes invalid Weather Widget settings", () => {
+    const normalized = normalizeTabState({
+      ...defaultTabState,
+      canvas: {
+        ...defaultTabState.canvas,
+        widgets: {
+          ...defaultTabState.canvas.widgets,
+          weather: {
+            ...defaultTabState.canvas.widgets.weather,
+            settings: {
+              ...defaultTabState.canvas.widgets.weather.settings,
+              locationName: "",
+              latitude: 200,
+              longitude: -300,
+              units: "kelvin",
+              displayMode: "custom",
+              refreshMinutes: 2
+            }
+          }
+        }
+      }
+    });
+
+    expect(normalized.canvas.widgets.weather.settings.locationName).toBe("London");
+    expect(normalized.canvas.widgets.weather.settings.latitude).toBe(90);
+    expect(normalized.canvas.widgets.weather.settings.longitude).toBe(-180);
+    expect(normalized.canvas.widgets.weather.settings.units).toBe("celsius");
+    expect(normalized.canvas.widgets.weather.settings.displayMode).toBe("expanded");
+    expect(normalized.canvas.widgets.weather.settings.refreshMinutes).toBe(5);
+  });
+
+  it("normalizes invalid Date & Time Widget settings", () => {
+    const normalized = normalizeTabState({
+      ...defaultTabState,
+      canvas: {
+        ...defaultTabState.canvas,
+        widgets: {
+          ...defaultTabState.canvas.widgets,
+          dateTime: {
+            ...defaultTabState.canvas.widgets.dateTime,
+            settings: {
+              ...defaultTabState.canvas.widgets.dateTime.settings,
+              clockMode: "analog",
+              timeFormat: "twentyfivehour",
+              dateMode: "calendar",
+              dateOrder: "DMYY",
+              shortSeparator: "comma",
+              timezone: "",
+              hourColor: ""
+            }
+          }
+        }
+      }
+    });
+
+    expect(normalized.canvas.widgets.dateTime.settings.clockMode).toBe("verticalClock");
+    expect(normalized.canvas.widgets.dateTime.settings.timeFormat).toBe("twentyFourHour");
+    expect(normalized.canvas.widgets.dateTime.settings.dateMode).toBe("long");
+    expect(normalized.canvas.widgets.dateTime.settings.dateOrder).toBe("DMY");
+    expect(normalized.canvas.widgets.dateTime.settings.shortSeparator).toBe("dots");
+    expect(normalized.canvas.widgets.dateTime.settings.timezone).toBe("auto");
+    expect(normalized.canvas.widgets.dateTime.settings.hourColor).toBe("#f8fafc");
+  });
 });
 
 describe("buildSearchUrl", () => {


### PR DESCRIPTION
## Summary
- Add first-class Weather and Date & Time widgets to the Canvas with persisted placement, settings, context menus, and normalization.
- Add Open-Meteo weather integration with geocoding, cached current conditions, expanded display mode, and Weather-style translucent glass UI.
- Add Mue-inspired Date & Time behavior without analog clock: vertical clock by default with seconds, long date formatting, percentage-complete and digital modes.
- Introduce shared translucent widget surface utilities and menu controls used by Search, Shortcut Grid, Weather, and Date & Time.
- Fix Shortcut Grid drag overlay rendering by portaling the overlay while preserving icon sizing variables.

## Testing
- npm test
- npm run build
- npm run test:smoke