### PR TITLE
Enhance widgets with responsive design and add RSS feed management

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,6 +23,24 @@ The Widget containing the search input and search-provider controls.
 **Shortcut Grid Widget**  
 The Widget containing Shortcut Pages, Top-Level Tiles, and tile/folder drag behavior.
 
+**Weather Widget**  
+The Widget showing a cached weather snapshot for a configured location, display mode, unit system, and refresh interval.
+
+**Date & Time Widget**  
+The Widget showing clock/date information. It supports digital, percentage-complete, and vertical clock modes plus date formatting and per-part colors.
+
+**Snap Feed Widget**  
+The Widget showing RSS/Atom feed articles from user-configured feed sources. It fetches feeds through the extension background worker, supports all-feeds and selected-feed modes, and displays feed/article thumbnails or fallback initials.
+
+**Feed Source**  
+A user-configured RSS/Atom subscription with ID, title, and URL. Feed Sources are persisted in `TabState` under the Snap Feed Widget settings.
+
+**Feed Item**  
+A normalized RSS/Atom article with title, link, source, optional snippet, publication date, author, and image URL. Feed Items are fetched/cache data, not user configuration.
+
+**OPML**  
+A portable XML subscription list used by the Snap Feed Widget. OPML import merges Feed Sources by default, skips duplicates, and can replace the current Feed Source list after confirmation.
+
 **Shortcut**  
 A top-level or folder-contained link with a title, URL, and icon.
 
@@ -91,12 +109,15 @@ A domain command produced from Drag Intent: `REORDER`, `COMBINE`, `ADD_TO_FOLDER
 - Wallpapers and uploaded icons remain portable as data URLs.
 - IndexedDB media storage is not part of the MVP runtime persistence path.
 - Theme choice is persisted in `TabState` and applies globally through CSS variables.
+- Snap Feed subscriptions are persisted in `TabState`; fetched Feed Items and feed check results are cache/transient data.
+- OPML import/export is scoped to Snap Feed subscriptions and is separate from JSON Backup.
 
 ### Product Structure
 
 - The New Tab Surface is a single React app, not multiple extension pages.
 - The Canvas is the whole interactive New Tab workspace and contains all user-arrangeable Widgets.
 - SnapTab has exactly one Search Widget and exactly one Shortcut Grid Widget.
+- SnapTab also has one Weather Widget, one Date & Time Widget, and one Snap Feed Widget.
 - Widgets can be disabled; disabled Widgets keep settings and last placement but do not reserve Canvas space.
 - Canvas Edit Mode is toggled from the toolbar, shows Widget frames/alignment guides, enables Widget movement/resizing, and disables tile drag.
 - The Toolbar Popup is a second React entry point that reuses the shortcut editor form and persisted store.
@@ -105,6 +126,19 @@ A domain command produced from Drag Intent: `REORDER`, `COMBINE`, `ADD_TO_FOLDER
 - A Folder always contains at least two Shortcuts; removal that leaves one child promotes it to the page.
 - Deleting a Folder deletes its contained Shortcuts.
 - The Toolbar Popup is the shortcut creation flow; the New Tab Surface does not show a Shortcut creation tile.
+
+### Snap Feed
+
+- Snap Feed fetches RSS/Atom XML through the Manifest V3 background service worker so host permissions apply to feeds that block browser CORS.
+- The manifest declares default `http` and `https` host permissions because feed fetching is a core Snap Feed capability.
+- The New Tab Surface still owns rendering and settings; the background worker only fetches feed text and returns it to the page for parsing.
+- Feed Source configuration stays clean: ID, title, and URL only.
+- Feed cache metadata records feed URL, cached items, last fetched time, last successful fetch, and last error outside Widget settings.
+- OPML import merges by default, skips duplicate feed URLs, and has a replace mode guarded by confirmation.
+- Feed checks validate whether each Feed Source can be fetched and parsed, then show green/red status in the Snap Feed context menu.
+- All-feeds mode is the default. Selected-feed mode is available in settings.
+- All-feeds mode applies an items-per-feed cap before applying the global item limit so one noisy source cannot hide other Feed Sources.
+- Feed rows prefer article image, then source favicon, then a generated initials fallback tile.
 
 ### Tile Management
 
@@ -150,6 +184,7 @@ A domain command produced from Drag Intent: `REORDER`, `COMBINE`, `ADD_TO_FOLDER
 - React 19 + TypeScript + Vite
 - Zustand + Immer for state management
 - chrome.storage.local for persistence
+- Manifest V3 background service worker for RSS/Atom feed fetches
 - Native HTML drag events
 - Motion (Framer Motion) with reduced motion support
 - Global CSS imported through `src/ui/styles.css`; selectors live in Module-owned CSS files beside their UI Modules.
@@ -173,6 +208,9 @@ A domain command produced from Drag Intent: `REORDER`, `COMBINE`, `ADD_TO_FOLDER
 - [x] Wallpaper upload
 - [x] JSON Backup export/import
 - [x] Page navigation (dots, wheel, keyboard)
+- [x] Weather Widget
+- [x] Date & Time Widget
+- [x] Snap Feed Widget with RSS/Atom parsing, OPML import/export, feed checks, refresh, thumbnails, and per-feed item limits
 - [x] Reduced motion support
 
 ### Reference Extension

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ SnapTab is a local-first Chrome new tab extension for building a personalized, f
 
 ## Overview
 
-SnapTab replaces Chrome's new tab page with a customizable workspace. It combines a search widget, paged shortcut grid, folders, wallpaper controls, and backup tools in a single Manifest V3 extension.
+SnapTab replaces Chrome's new tab page with a customizable workspace. It combines search, shortcuts, folders, weather, date/time, Snap Feed RSS, wallpaper controls, and backup tools in a single Manifest V3 extension.
 
 The app is shaped by familiar new tab productivity patterns, but it is its own implementation and product direction.
 
@@ -34,6 +34,9 @@ The app is shaped by familiar new tab productivity patterns, but it is its own i
 - Full-viewport Canvas with movable and resizable widgets
 - Search widget with configurable search providers and display options
 - Shortcut Grid widget with paged top-level tiles
+- Weather widget with location, units, display, and refresh controls
+- Date & Time widget with clock/date display modes and color controls
+- Snap Feed widget for RSS/Atom feeds with direct extension fetch, OPML import/export, feed checks, thumbnails, refresh, and per-feed item limits
 - Shortcut add, edit, delete, reorder, and drag behavior
 - Toolbar popup for saving the current active website as a shortcut
 - Folder creation by dragging shortcuts together
@@ -45,6 +48,7 @@ The app is shaped by familiar new tab productivity patterns, but it is its own i
 - Settings drawer for search, grid, wallpaper, and backup controls
 - JSON backup export and replace-only import
 - Local-first persistence through Chrome storage
+- RSS feed fetching through a Manifest V3 background service worker with default host permissions for `http` and `https` feeds
 - Reduced motion support
 
 ## Technology
@@ -118,6 +122,10 @@ SnapTab is local-first. There is no backend account or sync service in the curre
 Runtime state is persisted to `chrome.storage.local`, with a localStorage fallback for development. Backups are portable JSON files that replace the current state on import.
 
 Uploaded wallpapers and shortcut icons are kept portable as data URLs or media-backed records in the local extension environment.
+
+Snap Feed subscriptions are stored in the same local state and are included in JSON backups. OPML import/export is scoped to Snap Feed subscriptions only. Feed article caches remain runtime cache data and are not mixed into user feed configuration.
+
+The extension manifest includes broad `http`/`https` host permissions so the background service worker can fetch common RSS/Atom feeds that do not expose browser CORS headers. Test Snap Feed from the installed `chrome-extension://.../newtab.html` page; Vite dev pages still run as normal web origins.
 
 ## Project Docs
 

--- a/docs/adr/0005-canvas-widget-surface.md
+++ b/docs/adr/0005-canvas-widget-surface.md
@@ -1,6 +1,6 @@
 # Canvas Widget Surface
 
-SnapTab will move from a fixed page composition to a Canvas-based New Tab Surface. The Canvas fills the viewport, never browser-scrolls, and contains exactly one Search Widget and one Shortcut Grid Widget. Widgets persist enabled state, visual settings, type-specific settings, and freeform Canvas-relative placement. Canvas Edit Mode is transient and exposes Widget frames, alignment guides, and Widget movement/resizing controls.
+SnapTab will move from a fixed page composition to a Canvas-based New Tab Surface. The Canvas fills the viewport, never browser-scrolls, and initially established exactly one Search Widget and one Shortcut Grid Widget as the core surfaces. The same Canvas Widget pattern now also hosts Weather, Date & Time, and Snap Feed Widgets. Widgets persist enabled state, visual settings, type-specific settings, and freeform Canvas-relative placement. Canvas Edit Mode is transient and exposes Widget frames, alignment guides, and Widget movement/resizing controls.
 
 Shortcut Pages remain inside the Shortcut Grid Widget. Shortcut and Folder records continue to live in the existing flat tile map and `pages[].tileIds` order. The Toolbar Popup remains the shortcut creation flow, so the New Tab Surface no longer needs a Shortcut creation tile.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,7 +11,7 @@ SnapTab is a local-first Chrome new tab extension shaped by familiar new tab pro
 - Chrome Manifest V3 new tab override.
 - React + Vite new tab UI plus toolbar action popup.
 - Quick-link grid with add, edit, delete, active-page drag reorder, drag-combine folder creation, drag-add-to-folder, and FolderPanel child drag-out promotion.
-- Canvas-based New Tab Surface with movable/resizable Search and Shortcut Grid Widgets.
+- Canvas-based New Tab Surface with movable/resizable Search, Shortcut Grid, Weather, Date & Time, and Snap Feed Widgets.
 - Canvas edit toggle with Widget frames and alignment guides; tile drag is disabled while arranging Widgets.
 - Toolbar popup for adding the active browser tab as a shortcut with the shared shortcut editor form.
 - Folder tiles that open as modal overlays.
@@ -22,6 +22,9 @@ SnapTab is a local-first Chrome new tab extension shaped by familiar new tab pro
 - Search provider presets: Google, Bing, Yahoo, Yandex, DuckDuckGo.
 - Search Widget customization: enabled state, provider tabs, search mark, rounded corners, opacity.
 - Shortcut Grid Widget customization: enabled state, icon size, grid spacing, labels, page dots.
+- Weather Widget customization: location, units, display mode, refresh interval, and visual surface settings.
+- Date & Time Widget customization: clock mode, time/date formatting, seconds, color controls, and visual surface settings.
+- Snap Feed Widget customization: RSS/Atom Feed Sources, all-feeds or selected-feed mode, OPML import/export, feed checks, refresh interval, item limits, thumbnails, snippets, and visual surface settings.
 - Right-side settings drawer opened by a gear button.
 - Full JSON export/import backup with replace-only restore.
 - Automated build checks plus unit and browser smoke tests.
@@ -41,6 +44,7 @@ SnapTab is a local-first Chrome new tab extension shaped by familiar new tab pro
 
 ```text
 public/manifest.json          Chrome extension manifest
+public/background.js          Manifest V3 background worker for RSS/Atom feed fetches
 newtab.html                   New Tab Surface HTML entry
 popup.html                    Toolbar popup HTML entry
 src/main.tsx                  New Tab Surface React entry point
@@ -53,6 +57,9 @@ src/ui/canvas/useCanvasMetrics.ts  Canvas viewport metrics
 src/ui/popup/PopupApp.tsx     Toolbar add-current-site popup
 src/ui/widgets/search/*       Search Widget rendering, settings menu section, and styles
 src/ui/widgets/shortcut-grid/* Shortcut Grid Widget, Shortcut Pages, FolderPanel, drag shell, Shortcut tile/icon UI, and styles
+src/ui/widgets/weather/*      Weather Widget rendering, service, settings menu section, and styles
+src/ui/widgets/date-time/*    Date & Time Widget rendering, settings menu section, and styles
+src/ui/widgets/rss/*          Snap Feed Widget rendering, RSS fetch service, OPML controls, settings menu section, and styles
 src/ui/widgets/WidgetFrame.tsx Common Widget move/resize frame
 src/ui/widgets/WidgetContextMenu.tsx Common edit-mode Widget context menu shell
 src/ui/settings/*             Settings Drawer and settings sections
@@ -70,6 +77,7 @@ src/domain/drafts.ts          Shortcut and Folder edit draft contracts
 src/domain/tabOperations.ts   Shortcut, Folder, and layout mutation operations
 src/domain/dropActions.ts     Drag/drop actions and folder cleanup reducer
 src/domain/backup.ts          Backup parsing and compatibility defaults
+src/domain/rss.ts             OPML parsing, RSS/Atom parsing, and Feed Item normalization
 src/stores/useTabStore.ts     Zustand + immer persisted state store
 src/infrastructure/fileData.ts  File-to-data-URL adapter
 CONTEXT.md                    Domain glossary and current decisions
@@ -95,7 +103,9 @@ Top-level fields:
 - `tiles`: flat map of all `Shortcut` and `Folder` records by ID.
 - `pages`: ordered Shortcut Pages. Each page owns a `tileIds[]` list for Top-Level Tile display order.
 
-The Canvas stores exactly one Search Widget and one Shortcut Grid Widget. Widget placement is persisted in Canvas-relative units and may be fractional for freeform placement. Enabled Widgets cannot overlap; disabled Widgets keep settings and last placement but do not reserve Canvas space.
+The Canvas stores exactly one Search Widget, Shortcut Grid Widget, Weather Widget, Date & Time Widget, and Snap Feed Widget. Widget placement is persisted in Canvas-relative units and may be fractional for freeform placement. Enabled Widgets cannot overlap; disabled Widgets keep settings and last placement but do not reserve Canvas space.
+
+Snap Feed stores only user Feed Sources in Widget settings: ID, title, and URL. Fetched Feed Items and cache metadata stay outside Widget settings. All-feeds mode applies `maxItemsPerFeed` before the global item cap, so one noisy feed cannot hide quieter sources.
 
 `Shortcut` icons support three modes:
 
@@ -114,14 +124,19 @@ Wallpaper and uploaded shortcut icons are stored as portable data URLs inside `T
 The manifest includes:
 
 ```json
-"permissions": ["activeTab", "storage", "unlimitedStorage"]
+"permissions": ["activeTab", "storage", "tabs", "unlimitedStorage"],
+"host_permissions": ["https://*/*", "http://*/*"]
 ```
 
-`activeTab` lets the toolbar popup prefill the shortcut title and URL from the current tab. `unlimitedStorage` remains enabled for local-first storage headroom while media payloads remain in the persisted state blob.
+`activeTab` and `tabs` let the toolbar popup prefill the shortcut title and URL from the current tab. `unlimitedStorage` remains enabled for local-first storage headroom while media payloads remain in the persisted state blob. Host permissions allow the background service worker to fetch RSS/Atom feeds that block normal browser CORS requests.
+
+Snap Feed fetching runs through `public/background.js`. The New Tab Surface sends a feed URL to the service worker, the worker fetches the XML using extension host permissions, and the UI parses the returned text through `src/domain/rss.ts`. In Vite dev, where no extension service worker exists, the service falls back to direct `fetch` and may hit CORS.
 
 ## Backup And Restore
 
 JSON export serializes the full `TabState`, including wallpaper and uploaded icon data URLs so backups stay portable.
+
+Snap Feed subscriptions are included in JSON Backup as Widget settings. OPML import/export is separate and only moves Feed Sources, not wallpaper, shortcuts, widget placement, or fetched article cache.
 
 Import is replace-only:
 
@@ -170,6 +185,7 @@ Shortcut and Folder editing rules live in `src/domain/tabOperations.ts`. Drag/dr
 - The New Tab Surface is a fixed Canvas containing Widgets; it never browser-scrolls.
 - `CanvasWidgetHost` is the seam where Canvas mounts Widgets, wires Widget Placement changes, and hosts the common Widget Context Menu shell.
 - Widget-specific context menu controls live with their Widget Modules; the shared `WidgetContextMenu` owns only shell positioning and Canvas-level Widget toggles.
+- Snap Feed owns its feed management, OPML import/export, feed status checks, and refresh controls inside `src/ui/widgets/rss/`.
 - Canvas Edit Mode is transient, starts off on new tabs, and enables Widget movement/resizing.
 - Shortcut Pages live inside the Shortcut Grid Widget. Wheel navigation applies only while hovering that Widget in normal mode.
 - The New Tab Surface no longer renders a Shortcut creation tile; the Toolbar Popup is the shortcut creation flow.
@@ -198,8 +214,9 @@ Load the built extension from `dist/` through `chrome://extensions/` with Develo
 
 - Vite builds `newtab.html` and `popup.html` as Rollup inputs and removes `crossorigin` attributes during build.
 - Vitest runs `tests/unit/**/*.test.ts` in a Node environment.
+- Vitest also includes TSX unit tests; selected RSS parser/service tests run in jsdom for DOMParser and browser API seams.
 - Playwright smoke tests run from `tests/smoke/` against `http://127.0.0.1:4173`; its web server command is `npm run build && npm run preview -- --port 4173`.
-- Manifest V3 declares the new-tab override, toolbar action popup, `activeTab`, `storage`, and `unlimitedStorage`; there is no background script, content script, or icon set.
+- Manifest V3 declares the new-tab override, toolbar action popup, `activeTab`, `tabs`, `storage`, `unlimitedStorage`, broad `http`/`https` host permissions for Snap Feed, and a background service worker. There is no content script or icon set.
 
 ## Release Workflow
 
@@ -212,7 +229,7 @@ The workflow is manual-only, must run from `main`, installs with `npm ci`, auto-
 - **Done**: Drag/drop session logic extracted to `useGridDragSession` hook.
 - Drag UI routes most drops through `createDropAction()` but does not use domain `resolveDrop()` in production.
 - Touch drag is not implemented.
-- Favicon lookup for unknown websites is not implemented.
+- Snap Feed favicon lookup uses Google's favicon service as a non-blocking image fallback; shortcut favicon lookup for unknown websites is not implemented.
 - Keyboard focus trapping for modals/drawer is not complete.
 - Chrome Web Store assets and privacy text are not prepared.
 - dnd-kit is not installed; current drag implementation is native HTML drag. Reintroduce it only through a deliberate future ADR.

--- a/docs/hld.md
+++ b/docs/hld.md
@@ -6,17 +6,19 @@ SnapTab is a local-first Chrome Manifest V3 new-tab extension. Product shape con
 
 - Fixed full-viewport new tab page
 - Toolbar popup to add the current site
-- Canvas with movable/resizable Search and Shortcut Grid Widgets
+- Canvas with movable/resizable Search, Shortcut Grid, Weather, Date & Time, and Snap Feed Widgets
 - Paged shortcut grid with folders inside the Shortcut Grid Widget
 - Wallpaper layer (image/GIF)
 - Right-side settings drawer
 - JSON backup import/export
+- OPML import/export for Snap Feed subscriptions
 
 ## Architecture Layers
 
 ```
 Chrome Extension
   └─ public/manifest.json          # MV3 extension manifest
+      ├─ public/background.js       # RSS/Atom feed fetch worker
       ├─ src/main.tsx           # New Tab Surface React entry point
       │   └─ src/ui/app/App.tsx # New Tab Surface root component
       │       ├─ app/useNewTabController() # Transient UI state and store actions
@@ -25,6 +27,9 @@ Chrome Extension
       │       ├─ widgets/WidgetFrame       # Common Widget move/resize frame
       │       ├─ widgets/search/*          # Search Widget rendering and settings menu section
       │       ├─ widgets/shortcut-grid/*   # Shortcut Grid Widget, Shortcut Pages, folders, native drag, tile/icon UI
+      │       ├─ widgets/weather/*         # Weather Widget rendering, service, settings, and styles
+      │       ├─ widgets/date-time/*       # Date & Time Widget rendering, settings, and styles
+      │       ├─ widgets/rss/*             # Snap Feed Widget rendering, feed service, OPML controls, and styles
       │       ├─ settings/*                # Settings Drawer and settings sections
       │       ├─ modals/*                  # Shortcut and Folder edit overlays
       │       └─ shortcut-editor/*         # Shared Shortcut editor form
@@ -37,7 +42,8 @@ Domain Layer (src/domain/)
   ├─ drafts.ts          # Shortcut/Folder edit command drafts
   ├─ tabOperations.ts  # Resolved view models
   ├─ dropActions.ts   # DnD domain logic
-  └─ backup.ts      # Import/export
+  ├─ backup.ts      # JSON Backup import/export
+  └─ rss.ts         # OPML parsing, RSS/Atom parsing, Feed Item normalization
 
 Infrastructure Layer (src/infrastructure/)
   └─ fileData.ts    # Browser File API
@@ -55,6 +61,8 @@ Store Layer (src/stores/)
 | Drag Source / Drop Target to Drop Action | `createDropAction()` UI Adapter | `src/ui/drag/dropActionAdapter.ts`, `src/domain/dropActions.ts` |
 | Shortcut editing | `ShortcutDraft` and shared editor form | `src/domain/drafts.ts`, `src/ui/shortcut-editor/ShortcutForm.tsx` |
 | Persistence | Zustand persisted `TabState` | `src/stores/useTabStore.ts` with Chrome/localStorage fallback |
+| RSS/Atom fetch | Feed URL to XML text | New Tab Surface sends a runtime message to `public/background.js`; service worker fetches with manifest host permissions |
+| OPML import/export | Feed Source list | `src/domain/rss.ts`, `src/ui/widgets/rss/RssWidgetContextMenu.tsx` |
 
 ## State Model
 
@@ -102,7 +110,8 @@ Persisted `pages[].tileIds` is top-level order. The visible Shortcut Pages are d
 5. **One store**: All persisted state in Zustand + immer store
 6. **Local-first**: No backend, chrome.storage.local persistence
 7. **Canvas bounds**: Widgets persist freeform Canvas-relative placement and enabled Widgets cannot overlap
-8. **Widget ownership**: Search settings belong to Search Widget; Shortcut Grid settings belong to Shortcut Grid Widget
+8. **Widget ownership**: Each Widget owns rendering and settings; Canvas owns Widget placement, enabled state, and context menu mounting
+9. **Feed config separation**: Snap Feed persists Feed Sources only; fetched Feed Items and cache metadata remain runtime/cache data
 
 ## Product Surfaces
 
@@ -112,6 +121,9 @@ Persisted `pages[].tileIds` is top-level order. The visible Shortcut Pages are d
 | Canvas | Fixed full-viewport workspace containing Widgets |
 | Search Widget | Search input and provider controls |
 | Shortcut Grid Widget | Shortcut Pages, Top-Level Tiles, and tile drag/drop |
+| Weather Widget | Cached weather snapshot and weather settings |
+| Date & Time Widget | Clock/date display with formatting and per-part colors |
+| Snap Feed Widget | RSS/Atom Feed Sources, fetched Feed Items, OPML import/export, and feed checks |
 | Toolbar Popup | Add current active website as a Shortcut |
 | Shortcut Grid | Paged top-level tile grid |
 | Settings Drawer | Right-side settings |
@@ -132,6 +144,7 @@ Persisted `pages[].tileIds` is top-level order. The visible Shortcut Pages are d
 | Persistence | Zustand persist to chrome.storage.local | localStorage fallback in dev |
 | Animation | Motion (Framer Motion) | Reduced motion support |
 | Icons | Lucide + Simple Icons | Brand matching |
+| RSS fetch | MV3 background service worker | Host permissions apply to feeds that block browser CORS |
 
 ## Reference Extension Learnings
 
@@ -155,6 +168,7 @@ The extracted reference extension confirms:
 | Native drag | widgets/shortcut-grid/ShortcutGrid.tsx + useNativeDragOverlay | Custom overlay, no dnd-kit |
 | Canvas widget drag | widgets/WidgetFrame.tsx | Pointer-based move/resize in Canvas Edit Mode |
 | Widget mounting | canvas/CanvasWidgetHost.tsx | Canvas-owned Widget frames and context menu shell |
+| Snap Feed service | widgets/rss/rssService.ts + public/background.js | UI owns parsing/cache; background owns network fetch |
 | Shortcut Page model | widgets/shortcut-grid/shortcutPageModel.ts | Pure Grid Layout Capacity and page slicing math |
 | Zone timer | 200ms debounce | Timer in useRef |
 | Live shift | getTileShift() | FLIP-like animation |
@@ -173,7 +187,10 @@ The extracted reference extension confirms:
 - [x] Canvas Edit Mode with Widget frames and alignment guides
 - [x] Debounced Widget placement persistence with pointer-up flush
 - [x] Toolbar Popup-only Shortcut creation flow
-- [ ] Widget visual style customization controls
+- [x] Weather Widget
+- [x] Date & Time Widget
+- [x] Snap Feed Widget with RSS/Atom parsing, OPML import/export, feed checks, refresh, thumbnails, and per-feed item limits
+- [x] Widget visual style customization controls
 - [ ] Keyboard drag
 - [ ] Touch drag
 

--- a/public/background.js
+++ b/public/background.js
@@ -1,0 +1,23 @@
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (!message || message.type !== "SNAPTAB_FETCH_RSS_FEED" || typeof message.url !== "string") {
+    return false;
+  }
+
+  fetch(message.url)
+    .then(async (response) => {
+      sendResponse({
+        ok: response.ok,
+        status: response.status,
+        text: await response.text()
+      });
+    })
+    .catch((error) => {
+      sendResponse({
+        ok: false,
+        status: 0,
+        error: error instanceof Error ? error.message : "Feed unavailable."
+      });
+    });
+
+  return true;
+});

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,8 +7,12 @@
     "default_title": "Add to SnapTab",
     "default_popup": "popup.html"
   },
+  "background": {
+    "service_worker": "background.js"
+  },
   "chrome_url_overrides": {
     "newtab": "newtab.html"
   },
-  "permissions": ["activeTab", "storage", "tabs", "unlimitedStorage"]
+  "permissions": ["activeTab", "storage", "tabs", "unlimitedStorage"],
+  "host_permissions": ["https://*/*", "http://*/*"]
 }

--- a/src/domain/canvas.ts
+++ b/src/domain/canvas.ts
@@ -1,6 +1,6 @@
 import type { SearchProviderId, SearchVerticalId } from "./tabState";
 
-export type WidgetId = "search" | "shortcutGrid" | "weather" | "dateTime";
+export type WidgetId = "search" | "shortcutGrid" | "weather" | "dateTime" | "rss";
 
 export type WidgetPlacement = {
   x: number;
@@ -88,6 +88,29 @@ export type DateTimeWidgetSettings = {
   visual: WidgetVisualSettings;
 };
 
+export type RssFeed = {
+  id: string;
+  title: string;
+  url: string;
+};
+
+export type RssFeedMode = "all" | "selected";
+
+export type RssDisplayMode = "compact" | "standard" | "expanded";
+
+export type RssWidgetSettings = {
+  feeds: RssFeed[];
+  feedMode: RssFeedMode;
+  selectedFeedId: string | null;
+  displayMode: RssDisplayMode;
+  maxItems: number;
+  maxItemsPerFeed: number;
+  refreshMinutes: number;
+  showSource: boolean;
+  showSnippet: boolean;
+  visual: WidgetVisualSettings;
+};
+
 export type WidgetState<TSettings> = {
   enabled: boolean;
   placement: WidgetPlacement;
@@ -99,6 +122,7 @@ export type CanvasWidgets = {
   shortcutGrid: WidgetState<ShortcutGridWidgetSettings>;
   weather: WidgetState<WeatherWidgetSettings>;
   dateTime: WidgetState<DateTimeWidgetSettings>;
+  rss: WidgetState<RssWidgetSettings>;
 };
 
 export type CanvasState = {
@@ -119,6 +143,7 @@ const defaultSearchSize = { width: 11, height: 1 };
 const defaultShortcutGridSize = { width: 13, height: 7 };
 const defaultWeatherSize = { width: 7, height: 4 };
 const defaultDateTimeSize = { width: 7, height: 3 };
+const defaultRssSize = { width: 8, height: 5 };
 
 export const defaultWidgetVisualSettings: WidgetVisualSettings = {
   showBackground: false,
@@ -210,6 +235,28 @@ export const defaultCanvasState: CanvasState = {
           padding: 14
         }
       }
+    },
+    rss: {
+      enabled: true,
+      placement: deriveDefaultWidgetPlacements(fallbackCanvasGrid).rss,
+      settings: {
+        feeds: [],
+        feedMode: "all",
+        selectedFeedId: null,
+        displayMode: "standard",
+        maxItems: 8,
+        maxItemsPerFeed: 3,
+        refreshMinutes: 30,
+        showSource: true,
+        showSnippet: true,
+        visual: {
+          ...defaultWidgetVisualSettings,
+          showBackground: true,
+          backgroundOpacity: 26,
+          radius: 24,
+          padding: 12
+        }
+      }
     }
   }
 };
@@ -241,6 +288,8 @@ export function deriveDefaultWidgetPlacements(grid: CanvasGrid): Record<WidgetId
   const weatherHeight = Math.min(defaultWeatherSize.height, grid.rows);
   const dateTimeWidth = Math.min(defaultDateTimeSize.width, grid.columns);
   const dateTimeHeight = Math.min(defaultDateTimeSize.height, grid.rows);
+  const rssWidth = Math.min(defaultRssSize.width, grid.columns);
+  const rssHeight = Math.min(defaultRssSize.height, grid.rows);
 
   return {
     search: searchPlacement,
@@ -270,6 +319,16 @@ export function deriveDefaultWidgetPlacements(grid: CanvasGrid): Record<WidgetId
         y: 0,
         width: dateTimeWidth,
         height: dateTimeHeight,
+        zIndex: 8
+      },
+      grid
+    ),
+    rss: clampPlacementToCanvas(
+      {
+        x: Math.max(0, grid.columns - rssWidth),
+        y: 0,
+        width: rssWidth,
+        height: rssHeight,
         zIndex: 8
       },
       grid
@@ -402,6 +461,10 @@ function isKnownDefaultWidgetPlacement(widgetId: WidgetId, placement: WidgetPlac
     dateTime: [
       fallbackDefaults.dateTime,
       { x: 0, y: 0, width: 7, height: 3, zIndex: 8 }
+    ],
+    rss: [
+      fallbackDefaults.rss,
+      { x: 26, y: 0, width: 8, height: 5, zIndex: 8 }
     ]
   };
 

--- a/src/domain/canvas.ts
+++ b/src/domain/canvas.ts
@@ -117,7 +117,7 @@ const widgetGap = 2;
 const canvasBottomMargin = 1;
 const defaultSearchSize = { width: 11, height: 1 };
 const defaultShortcutGridSize = { width: 13, height: 7 };
-const defaultWeatherSize = { width: 5, height: 3 };
+const defaultWeatherSize = { width: 7, height: 4 };
 const defaultDateTimeSize = { width: 7, height: 3 };
 
 export const defaultWidgetVisualSettings: WidgetVisualSettings = {

--- a/src/domain/rss.ts
+++ b/src/domain/rss.ts
@@ -1,0 +1,318 @@
+import type { RssFeed } from "./canvas";
+
+export type RssItem = {
+  id: string;
+  feedId: string;
+  feedTitle: string;
+  title: string;
+  link: string;
+  snippet?: string;
+  publishedAt?: string;
+  author?: string;
+  imageUrl?: string;
+};
+
+export type RssFeedCache = {
+  feedUrl: string;
+  items: RssItem[];
+  lastFetchedAt: string;
+  lastSuccessAt?: string;
+  lastError?: string;
+};
+
+export type ParsedRssFeed = {
+  title: string;
+  items: RssItem[];
+};
+
+export function parseOpmlFeeds(xmlText: string): RssFeed[] {
+  const document = parseXml(escapeLooseXmlAttributeAmpersands(xmlText), "OPML file");
+  const outlines = Array.from(document.querySelectorAll("outline"));
+  const seenUrls = new Set<string>();
+  const feeds: RssFeed[] = [];
+
+  for (const outline of outlines) {
+    const url = normalizeFeedUrl(outline.getAttribute("xmlUrl") ?? outline.getAttribute("xmlurl"));
+    if (!url || seenUrls.has(url)) {
+      continue;
+    }
+
+    seenUrls.add(url);
+    const title = normalizeText(outline.getAttribute("title") ?? outline.getAttribute("text")) ?? getFeedTitleFromUrl(url);
+    feeds.push({ id: createRssFeedId(url), title, url });
+  }
+
+  return feeds;
+}
+
+export function serializeOpmlFeeds(feeds: RssFeed[]): string {
+  const outlines = feeds
+    .map((feed) => {
+      const title = escapeXml(feed.title);
+      const url = escapeXml(feed.url);
+      return `    <outline text="${title}" title="${title}" type="rss" xmlUrl="${url}" />`;
+    })
+    .join("\n");
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<opml version="2.0">',
+    "  <head>",
+    "    <title>SnapTab RSS Feeds</title>",
+    "  </head>",
+    "  <body>",
+    outlines,
+    "  </body>",
+    "</opml>"
+  ].join("\n");
+}
+
+export function parseRssXml(xmlText: string, feed: RssFeed): ParsedRssFeed {
+  const document = parseXml(xmlText, "RSS feed");
+  const channel = document.querySelector("channel");
+  if (channel) {
+    return parseRssChannel(channel, feed);
+  }
+
+  const atomFeed = document.querySelector("feed");
+  if (atomFeed) {
+    return parseAtomFeed(atomFeed, feed);
+  }
+
+  throw new Error("Unsupported RSS feed format.");
+}
+
+export function dedupeRssItems(items: RssItem[]): RssItem[] {
+  const seen = new Set<string>();
+  const deduped: RssItem[] = [];
+
+  for (const item of items) {
+    const key = item.link ? `${item.feedId}:${item.link}` : `${item.feedId}:${item.title}:${item.publishedAt ?? ""}`;
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    deduped.push(item);
+  }
+
+  return deduped;
+}
+
+export function createRssFeedId(url: string) {
+  return `rss-${hashString(url)}`;
+}
+
+export function normalizeFeedUrl(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const url = new URL(value.trim());
+    if (url.protocol !== "https:" && url.protocol !== "http:") {
+      return null;
+    }
+
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function parseRssChannel(channel: Element, feed: RssFeed): ParsedRssFeed {
+  const feedTitle = readChildText(channel, "title") ?? feed.title;
+  const items = Array.from(channel.querySelectorAll("item")).map((item) => {
+    const title = readChildText(item, "title") ?? "Untitled";
+    const link = readChildText(item, "link") ?? feed.url;
+    const publishedAt = normalizeDateText(readChildText(item, "pubDate") ?? readChildText(item, "dc\\:date"));
+    const snippet = normalizeSnippet(readChildText(item, "description") ?? readChildText(item, "content\\:encoded"));
+    const author = normalizeText(readChildText(item, "author") ?? readChildText(item, "dc\\:creator")) ?? undefined;
+    const imageUrl = getRssItemImageUrl(item, link ?? feed.url);
+    const id = readChildText(item, "guid") ?? link ?? `${title}:${publishedAt ?? ""}`;
+
+    return normalizeRssItem({ id, feed, feedTitle, title, link, publishedAt, snippet, author, imageUrl });
+  });
+
+  return { title: feedTitle, items: dedupeRssItems(items) };
+}
+
+function parseAtomFeed(atomFeed: Element, feed: RssFeed): ParsedRssFeed {
+  const feedTitle = readChildText(atomFeed, "title") ?? feed.title;
+  const entries = Array.from(atomFeed.querySelectorAll("entry"));
+  const items = entries.map((entry) => {
+    const title = readChildText(entry, "title") ?? "Untitled";
+    const link = readAtomLink(entry) ?? feed.url;
+    const publishedAt = normalizeDateText(readChildText(entry, "published") ?? readChildText(entry, "updated"));
+    const snippet = normalizeSnippet(readChildText(entry, "summary") ?? readChildText(entry, "content"));
+    const author = normalizeText(entry.querySelector("author > name")?.textContent) ?? undefined;
+    const imageUrl = getHtmlImageUrl(readChildText(entry, "content") ?? readChildText(entry, "summary"), link ?? feed.url);
+    const id = readChildText(entry, "id") ?? link ?? `${title}:${publishedAt ?? ""}`;
+
+    return normalizeRssItem({ id, feed, feedTitle, title, link, publishedAt, snippet, author, imageUrl });
+  });
+
+  return { title: feedTitle, items: dedupeRssItems(items) };
+}
+
+function normalizeRssItem({
+  id,
+  feed,
+  feedTitle,
+  title,
+  link,
+  publishedAt,
+  snippet,
+  author,
+  imageUrl
+}: {
+  id: string;
+  feed: RssFeed;
+  feedTitle: string;
+  title: string;
+  link: string;
+  publishedAt?: string;
+  snippet?: string;
+  author?: string;
+  imageUrl?: string;
+}): RssItem {
+  return {
+    id: `${feed.id}:${hashString(id)}`,
+    feedId: feed.id,
+    feedTitle,
+    title,
+    link,
+    ...(snippet ? { snippet } : {}),
+    ...(publishedAt ? { publishedAt } : {}),
+    ...(author ? { author } : {}),
+    ...(imageUrl ? { imageUrl } : {})
+  };
+}
+
+function getRssItemImageUrl(item: Element, baseUrl: string) {
+  const mediaThumbnail = normalizeImageUrl(getElementsByLocalName(item, "thumbnail")[0]?.getAttribute("url"), baseUrl);
+  if (mediaThumbnail) {
+    return mediaThumbnail;
+  }
+
+  const mediaContent = getElementsByLocalName(item, "content")
+    .map((element) => ({ type: element.getAttribute("type"), url: element.getAttribute("url") }))
+    .find((media) => media.url && (!media.type || media.type.startsWith("image/")));
+  const mediaContentUrl = normalizeImageUrl(mediaContent?.url, baseUrl);
+  if (mediaContentUrl) {
+    return mediaContentUrl;
+  }
+
+  const enclosure = Array.from(item.querySelectorAll("enclosure"))
+    .map((element) => ({ type: element.getAttribute("type"), url: element.getAttribute("url") }))
+    .find((candidate) => candidate.url && candidate.type?.startsWith("image/"));
+  const enclosureUrl = normalizeImageUrl(enclosure?.url, baseUrl);
+  if (enclosureUrl) {
+    return enclosureUrl;
+  }
+
+  return getHtmlImageUrl(readChildText(item, "description") ?? readChildText(item, "content\\:encoded"), baseUrl);
+}
+
+function getElementsByLocalName(element: Element, localName: string) {
+  return Array.from(element.getElementsByTagName("*")).filter((candidate) => candidate.localName === localName);
+}
+
+function getHtmlImageUrl(html: string | null | undefined, baseUrl: string) {
+  const source = html?.match(/<img\b[^>]*\bsrc=["']([^"']+)["'][^>]*>/i)?.[1];
+  return normalizeImageUrl(source, baseUrl);
+}
+
+function normalizeImageUrl(value: string | null | undefined, baseUrl: string) {
+  if (!value) {
+    return undefined;
+  }
+
+  try {
+    const url = new URL(value.trim(), baseUrl);
+    if (url.protocol !== "https:" && url.protocol !== "http:") {
+      return undefined;
+    }
+
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function readAtomLink(entry: Element) {
+  const alternate = Array.from(entry.querySelectorAll("link")).find((link) => {
+    const rel = link.getAttribute("rel");
+    return !rel || rel === "alternate";
+  });
+
+  return normalizeText(alternate?.getAttribute("href") ?? alternate?.textContent);
+}
+
+function readChildText(element: Element, selector: string) {
+  return normalizeText(element.querySelector(selector)?.textContent);
+}
+
+function normalizeText(value: string | null | undefined): string | null {
+  const text = value?.trim();
+  return text ? text : null;
+}
+
+function normalizeSnippet(value: string | null | undefined): string | undefined {
+  const text = normalizeText(value);
+  if (!text) {
+    return undefined;
+  }
+
+  const stripped = text.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
+  return stripped ? stripped.slice(0, 280) : undefined;
+}
+
+function normalizeDateText(value: string | null | undefined): string | undefined {
+  const text = normalizeText(value);
+  if (!text) {
+    return undefined;
+  }
+
+  const timestamp = Date.parse(text);
+  return Number.isNaN(timestamp) ? undefined : new Date(timestamp).toISOString();
+}
+
+function getFeedTitleFromUrl(url: string) {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return "RSS Feed";
+  }
+}
+
+function parseXml(xmlText: string, label: string) {
+  const document = new DOMParser().parseFromString(xmlText.trimStart(), "text/xml");
+  if (document.querySelector("parsererror")) {
+    throw new Error(`${label} is not valid XML.`);
+  }
+
+  return document;
+}
+
+function escapeXml(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function escapeLooseXmlAttributeAmpersands(xmlText: string) {
+  return xmlText.replace(/&(?!#\d+;|#x[\da-fA-F]+;|[a-zA-Z][\w.-]*;)/g, "&amp;");
+}
+
+function hashString(value: string) {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
+  }
+
+  return hash.toString(36);
+}

--- a/src/domain/tabState.ts
+++ b/src/domain/tabState.ts
@@ -7,9 +7,12 @@ import {
   type DateTimeDateOrder,
   type DateTimeFormat,
   type DateTimeShortSeparator,
+  type RssDisplayMode,
+  type RssFeedMode,
   type WeatherDisplayMode,
   type WeatherUnits
 } from "./canvas";
+import { createRssFeedId, normalizeFeedUrl } from "./rss";
 import { defaultThemeId, isThemeId, type ThemeId } from "./themes";
 
 export type SearchProviderId = "google" | "bing" | "yahoo" | "yandex" | "duckduckgo";
@@ -439,7 +442,8 @@ export function normalizeCanvasState(value: unknown, fallbackState?: Partial<Tab
           }
         },
         weather: fallback.widgets.weather,
-        dateTime: fallback.widgets.dateTime
+        dateTime: fallback.widgets.dateTime,
+        rss: fallback.widgets.rss
       }
     };
   }
@@ -451,7 +455,8 @@ export function normalizeCanvasState(value: unknown, fallbackState?: Partial<Tab
       search: normalizeSearchWidget(widgets.search, fallback.widgets.search, legacySearchProvider),
       shortcutGrid: normalizeShortcutGridWidget(widgets.shortcutGrid, fallback.widgets.shortcutGrid),
       weather: normalizeWeatherWidget(widgets.weather, fallback.widgets.weather),
-      dateTime: normalizeDateTimeWidget(widgets.dateTime, fallback.widgets.dateTime)
+      dateTime: normalizeDateTimeWidget(widgets.dateTime, fallback.widgets.dateTime),
+      rss: normalizeRssWidget(widgets.rss, fallback.widgets.rss)
     }
   };
 }
@@ -580,6 +585,89 @@ function normalizeDateTimeWidget(
       visual: normalizeWidgetVisualSettings(settings.visual, fallback.settings.visual)
     }
   };
+}
+
+function normalizeRssWidget(value: unknown, fallback: CanvasState["widgets"]["rss"]): CanvasState["widgets"]["rss"] {
+  if (!isRecord(value)) {
+    return fallback;
+  }
+
+  const settings = isRecord(value.settings) ? value.settings : {};
+  const feeds = normalizeRssFeeds(settings.feeds, fallback.settings.feeds);
+  const selectedFeedId = normalizeSelectedRssFeedId(settings.selectedFeedId, feeds, fallback.settings.selectedFeedId);
+  return {
+    enabled: typeof value.enabled === "boolean" ? value.enabled : fallback.enabled,
+    placement: normalizeWidgetPlacement(value.placement, fallback.placement),
+    settings: {
+      ...fallback.settings,
+      feeds,
+      feedMode: isRssFeedMode(settings.feedMode) ? settings.feedMode : fallback.settings.feedMode,
+      selectedFeedId,
+      displayMode: isRssDisplayMode(settings.displayMode) ? settings.displayMode : fallback.settings.displayMode,
+      maxItems: clampInteger(settings.maxItems, 1, 20, fallback.settings.maxItems),
+      maxItemsPerFeed: clampInteger(settings.maxItemsPerFeed, 1, 10, fallback.settings.maxItemsPerFeed),
+      refreshMinutes: clampInteger(settings.refreshMinutes, 5, 240, fallback.settings.refreshMinutes),
+      showSource: typeof settings.showSource === "boolean" ? settings.showSource : fallback.settings.showSource,
+      showSnippet: typeof settings.showSnippet === "boolean" ? settings.showSnippet : fallback.settings.showSnippet,
+      visual: normalizeWidgetVisualSettings(settings.visual, fallback.settings.visual)
+    }
+  };
+}
+
+function normalizeRssFeeds(value: unknown, fallback: CanvasState["widgets"]["rss"]["settings"]["feeds"]) {
+  if (!Array.isArray(value)) {
+    return fallback;
+  }
+
+  const seenUrls = new Set<string>();
+  const feeds: CanvasState["widgets"]["rss"]["settings"]["feeds"] = [];
+  for (const item of value) {
+    if (!isRecord(item)) {
+      continue;
+    }
+
+    const url = normalizeFeedUrl(typeof item.url === "string" ? item.url : null);
+    if (!url || seenUrls.has(url)) {
+      continue;
+    }
+
+    seenUrls.add(url);
+    const title = normalizeRssFeedTitle(item.title, url);
+    const id = typeof item.id === "string" && item.id.trim().length > 0 && item.id.length <= 80 ? item.id : createRssFeedId(url);
+    feeds.push({ id, title, url });
+    if (feeds.length >= 100) {
+      break;
+    }
+  }
+
+  return feeds;
+}
+
+function normalizeRssFeedTitle(value: unknown, url: string) {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.length > 0 && trimmed.length <= 120) {
+      return trimmed;
+    }
+  }
+
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return "RSS Feed";
+  }
+}
+
+function normalizeSelectedRssFeedId(
+  value: unknown,
+  feeds: CanvasState["widgets"]["rss"]["settings"]["feeds"],
+  fallback: string | null
+) {
+  if (typeof value !== "string") {
+    return fallback && feeds.some((feed) => feed.id === fallback) ? fallback : null;
+  }
+
+  return feeds.some((feed) => feed.id === value) ? value : null;
 }
 
 function normalizeWidgetPlacement(value: unknown, fallback: CanvasState["widgets"]["search"]["placement"]) {
@@ -894,6 +982,14 @@ function isWeatherUnits(value: unknown): value is WeatherUnits {
 }
 
 function isWeatherDisplayMode(value: unknown): value is WeatherDisplayMode {
+  return value === "compact" || value === "standard" || value === "expanded";
+}
+
+function isRssFeedMode(value: unknown): value is RssFeedMode {
+  return value === "all" || value === "selected";
+}
+
+function isRssDisplayMode(value: unknown): value is RssDisplayMode {
   return value === "compact" || value === "standard" || value === "expanded";
 }
 

--- a/src/stores/useTabStore.ts
+++ b/src/stores/useTabStore.ts
@@ -18,7 +18,9 @@ const storageKey = "snapTabState";
 const legacyStorageKey = ["in", "fi", "TabState"].join("");
 
 type TabStoreState = TabState & {
+  hasHydrated: boolean;
   replaceState: (state: TabState) => void;
+  setHasHydrated: (hasHydrated: boolean) => void;
   updateState: (update: (state: TabState) => TabState) => TabState;
   setLayout: <K extends keyof LayoutSettings>(key: K, value: LayoutSettings[K]) => void;
   setSearchProvider: (providerId: SearchProviderId) => void;
@@ -30,9 +32,14 @@ export const useTabStore = create<TabStoreState>()(
   persist(
     immer((set) => ({
       ...defaultTabState,
+      hasHydrated: false,
       replaceState: (state) =>
         set((draft) => {
           Object.assign(draft, normalizeTabState(state));
+        }),
+      setHasHydrated: (hasHydrated) =>
+        set((draft) => {
+          draft.hasHydrated = hasHydrated;
         }),
       updateState: (update) => {
         const nextState = update(stripActions(useTabStore.getState()));
@@ -71,6 +78,9 @@ export const useTabStore = create<TabStoreState>()(
         ...currentState,
         ...normalizeTabState(toRecord(persistedState))
       }),
+      onRehydrateStorage: () => (state) => {
+        state?.setHasHydrated(true);
+      },
       migrate: (persistedState, version) =>
         version === 1
           ? migrateLegacyTabState(persistedState as Partial<LegacyTabState>)
@@ -78,6 +88,28 @@ export const useTabStore = create<TabStoreState>()(
     }
   )
 );
+
+export function subscribeToExternalTabStateChanges() {
+  const chromeStorage = typeof chrome !== "undefined" ? chrome.storage : undefined;
+  const handleChromeStorageChange = (changes: Record<string, unknown>, areaName: string) => {
+    if (areaName === "local" && changes[storageKey]) {
+      void useTabStore.persist.rehydrate();
+    }
+  };
+  const handleLocalStorageChange = (event: StorageEvent) => {
+    if (event.key === storageKey) {
+      void useTabStore.persist.rehydrate();
+    }
+  };
+
+  chromeStorage?.onChanged?.addListener(handleChromeStorageChange);
+  window.addEventListener("storage", handleLocalStorageChange);
+
+  return () => {
+    chromeStorage?.onChanged?.removeListener(handleChromeStorageChange);
+    window.removeEventListener("storage", handleLocalStorageChange);
+  };
+}
 
 function stripActions(state: TabStoreState): TabState {
   return {

--- a/src/ui/app/App.tsx
+++ b/src/ui/app/App.tsx
@@ -1,6 +1,6 @@
-import { CSSProperties, Suspense, lazy, useState } from "react";
-import { defaultTabState } from "../../domain/tabState";
+import { CSSProperties, Suspense, lazy, useEffect, useState } from "react";
 import { getThemePreset } from "../../domain/themes";
+import { subscribeToExternalTabStateChanges, useTabStore } from "../../stores/useTabStore";
 import type { DragSource } from "../drag/dragModel";
 import { CanvasWidgetHost } from "../canvas";
 import { useNewTabController } from "./useNewTabController";
@@ -13,11 +13,14 @@ const FolderPanel = lazy(() => import("../widgets/shortcut-grid/FolderPanel").th
 
 export function App() {
   const controller = useNewTabController();
+  const hasHydrated = useTabStore((state) => state.hasHydrated);
   const [query, setQuery] = useState("");
   const [isCanvasEditMode, setIsCanvasEditMode] = useState(false);
   const [outgoingDragSource, setOutgoingDragSource] = useState<DragSource | null>(null);
 
-  const tabState = controller.tabState ?? defaultTabState;
+  useEffect(() => subscribeToExternalTabStateChanges(), []);
+
+  const tabState = controller.tabState;
   const canvasMetrics = useCanvasMetrics(tabState.canvas.targetCellSize);
   const searchWidget = tabState.canvas.widgets.search;
   const searchSettings = searchWidget.settings;
@@ -41,7 +44,7 @@ export function App() {
     "--wallpaper-blur": `${tabState.wallpaper.blur}px`
   } as CSSProperties;
 
-  if (!controller.tabState) {
+  if (!hasHydrated) {
     return <main className="new-tab loading">Loading</main>;
   }
 

--- a/src/ui/app/App.tsx
+++ b/src/ui/app/App.tsx
@@ -114,8 +114,8 @@ export function App() {
             activeShortcutPageIndex={controller.activeShortcutPage}
             dispatchDropAction={controller.dispatchDropAction}
             onClose={() => controller.setActiveFolderId(null)}
-            onEditFolder={controller.openEditFolderDialog}
             onEditShortcut={(shortcut) => controller.openEditShortcutDialog(shortcut, controller.activeFolder?.id ?? null)}
+            onRenameFolder={controller.renameFolder}
             onStartOutgoingDrag={(source) => {
               setOutgoingDragSource(source);
             }}

--- a/src/ui/app/useNewTabController.ts
+++ b/src/ui/app/useNewTabController.ts
@@ -158,11 +158,34 @@ export function useNewTabController() {
 
   function changeShortcutGridWidgetSetting<K extends keyof ShortcutGridWidgetSettings>(
     key: K,
-    value: ShortcutGridWidgetSettings[K]
+    value: ShortcutGridWidgetSettings[K],
+    grid?: CanvasGrid & { cellWidth: number; cellHeight: number }
   ) {
     updateTabState((state) =>
       produce(state, (draft) => {
-        draft.canvas.widgets.shortcutGrid.settings[key] = value;
+        const widget = draft.canvas.widgets.shortcutGrid;
+        const previousSettings = widget.settings;
+        widget.settings[key] = value;
+
+        if (key === "iconSize" && typeof value === "number" && grid) {
+          const currentWidth = widget.placement.width * grid.cellWidth;
+          const currentHeight = widget.placement.height * grid.cellHeight;
+          const previousScale = previousSettings.iconSize / 100;
+          const nextScale = value / 100;
+          const previousTileWidth = Math.max(84, 86 * previousScale + 30);
+          const previousTileHeight = Math.max(84, 86 * previousScale + (previousSettings.showLabels ? 42 : 18));
+          const columns = Math.max(1, Math.floor(currentWidth / previousTileWidth));
+          const rows = Math.max(1, Math.floor((currentHeight - 56) / previousTileHeight));
+          const nextTileWidth = Math.max(84, 86 * nextScale + 30);
+          const nextTileHeight = Math.max(84, 86 * nextScale + (widget.settings.showLabels ? 42 : 18));
+          const nextPlacement = {
+            ...widget.placement,
+            width: Math.max(widget.placement.width, Math.ceil((columns * nextTileWidth) / grid.cellWidth)),
+            height: Math.max(widget.placement.height, Math.ceil((rows * nextTileHeight + 56) / grid.cellHeight))
+          };
+
+          widget.placement = resolveWidgetPlacement(nextPlacement, grid, draft.canvas.widgets, "shortcutGrid", widget.placement);
+        }
       })
     );
   }
@@ -171,6 +194,17 @@ export function useNewTabController() {
     updateTabState((state) =>
       produce(state, (draft) => {
         draft.canvas.widgets.weather.settings[key] = value;
+      })
+    );
+  }
+
+  function changeWeatherWidgetSettings(settings: Partial<WeatherWidgetSettings>) {
+    updateTabState((state) =>
+      produce(state, (draft) => {
+        draft.canvas.widgets.weather.settings = {
+          ...draft.canvas.widgets.weather.settings,
+          ...settings
+        };
       })
     );
   }
@@ -407,6 +441,7 @@ export function useNewTabController() {
     changeShortcutGridWidgetSetting,
     changeTheme,
     changeWallpaperSetting,
+    changeWeatherWidgetSettings,
     chooseRecommendedIcon,
     deleteFolder,
     deleteShortcut,

--- a/src/ui/app/useNewTabController.ts
+++ b/src/ui/app/useNewTabController.ts
@@ -32,6 +32,7 @@ import { applyDropAction, type DropAction } from "../../domain/dropActions";
 import {
   type CanvasGrid,
   type DateTimeWidgetSettings,
+  type RssWidgetSettings,
   type SearchWidgetSettings,
   type ShortcutGridWidgetSettings,
   type WeatherWidgetSettings,
@@ -217,12 +218,50 @@ export function useNewTabController() {
     );
   }
 
+  function changeRssWidgetSetting<K extends keyof RssWidgetSettings>(key: K, value: RssWidgetSettings[K]) {
+    updateTabState((state) =>
+      produce(state, (draft) => {
+        draft.canvas.widgets.rss.settings[key] = value;
+      })
+    );
+  }
+
+  function changeRssWidgetSettings(settings: Partial<RssWidgetSettings>) {
+    updateTabState((state) =>
+      produce(state, (draft) => {
+        draft.canvas.widgets.rss.settings = {
+          ...draft.canvas.widgets.rss.settings,
+          ...settings
+        };
+      })
+    );
+  }
+
   function changeLayout<K extends keyof TabState["layout"]>(key: K, value: TabState["layout"][K]) {
     setLayout(key, value);
   }
 
   function changeTheme(themeId: ThemeId) {
     setTheme(themeId);
+  }
+
+  function renameFolder(folderId: string, title: string) {
+    const trimmedTitle = title.trim();
+    if (!trimmedTitle) {
+      return;
+    }
+
+    updateTabState((state) =>
+      produce(state, (draft) => {
+        const folder = draft.tiles[folderId];
+        if (folder?.kind !== "folder") {
+          return;
+        }
+
+        folder.title = trimmedTitle;
+        folder.icon.label = (trimmedTitle.slice(0, 1) || "?").toUpperCase();
+      })
+    );
   }
 
   function openEditShortcutDialog(shortcut: Shortcut, folderId: string | null = null) {
@@ -435,6 +474,8 @@ export function useNewTabController() {
     backupMessage,
     changeLayout,
     changeDateTimeWidgetSetting,
+    changeRssWidgetSetting,
+    changeRssWidgetSettings,
     changeSearchProvider,
     changeSearchWidgetSetting,
     changeWeatherWidgetSetting,
@@ -457,6 +498,7 @@ export function useNewTabController() {
     shortcutDraft,
     shortcutIconRecommendations,
     resetWallpaper,
+    renameFolder,
     saveFolder,
     saveShortcut,
     setActiveFolderId,

--- a/src/ui/canvas/CanvasWidgetHost.tsx
+++ b/src/ui/canvas/CanvasWidgetHost.tsx
@@ -31,9 +31,11 @@ export type CanvasWidgetController = {
   changeSearchWidgetSetting: <K extends keyof SearchWidgetSettings>(key: K, value: SearchWidgetSettings[K]) => void;
   changeShortcutGridWidgetSetting: <K extends keyof ShortcutGridWidgetSettings>(
     key: K,
-    value: ShortcutGridWidgetSettings[K]
+    value: ShortcutGridWidgetSettings[K],
+    grid?: CanvasGrid & { cellWidth: number; cellHeight: number }
   ) => void;
   changeWeatherWidgetSetting: <K extends keyof WeatherWidgetSettings>(key: K, value: WeatherWidgetSettings[K]) => void;
+  changeWeatherWidgetSettings: (settings: Partial<WeatherWidgetSettings>) => void;
   dispatchDropAction: (action: DropAction) => void;
   gridRef: RefObject<HTMLElement | null>;
   hasOverlayOpen: boolean;
@@ -204,8 +206,9 @@ export function CanvasWidgetHost({
       {contextMenu ? (
         <WidgetContextMenu
           changeSearchWidgetSetting={controller.changeSearchWidgetSetting}
-          changeShortcutGridWidgetSetting={controller.changeShortcutGridWidgetSetting}
+          changeShortcutGridWidgetSetting={(key, value) => controller.changeShortcutGridWidgetSetting(key, value, canvasMetrics)}
           changeWeatherWidgetSetting={controller.changeWeatherWidgetSetting}
+          changeWeatherWidgetSettings={controller.changeWeatherWidgetSettings}
           changeDateTimeWidgetSetting={controller.changeDateTimeWidgetSetting}
           close={() => setContextMenu(null)}
           menu={contextMenu}

--- a/src/ui/canvas/CanvasWidgetHost.tsx
+++ b/src/ui/canvas/CanvasWidgetHost.tsx
@@ -3,6 +3,7 @@ import {
   resolveResponsiveDefaultWidgetPlacement,
   type CanvasGrid,
   type DateTimeWidgetSettings,
+  type RssWidgetSettings,
   type SearchWidgetSettings,
   type ShortcutGridWidgetSettings,
   type WeatherWidgetSettings,
@@ -10,7 +11,7 @@ import {
   type WidgetPlacement
 } from "../../domain/canvas";
 import type { DropAction } from "../../domain/dropActions";
-import type { ResolvedFolder, ResolvedTopLevelTile } from "../../domain/tabOperations";
+import type { ResolvedTopLevelTile } from "../../domain/tabOperations";
 import { searchProviders, type SearchProviderId, type SearchVerticalId, type Shortcut, type TabState } from "../../domain/tabState";
 import type { DragSource } from "../drag/dragModel";
 import { WidgetContextMenu, type ContextMenuState } from "../widgets/WidgetContextMenu";
@@ -19,6 +20,7 @@ import { SearchWidget } from "../widgets/search";
 import { ShortcutGridWidget } from "../widgets/shortcut-grid";
 import { WeatherWidget } from "../widgets/weather";
 import { DateTimeWidget } from "../widgets/date-time";
+import { RssWidget } from "../widgets/rss";
 import { CanvasSurface } from "./CanvasSurface";
 
 type CanvasMetrics = ReturnType<typeof import("./useCanvasMetrics").useCanvasMetrics>;
@@ -27,6 +29,8 @@ export type CanvasWidgetController = {
   activeSearchProvider: (typeof searchProviders)[SearchProviderId];
   activeShortcutPage: number;
   changeDateTimeWidgetSetting: <K extends keyof DateTimeWidgetSettings>(key: K, value: DateTimeWidgetSettings[K]) => void;
+  changeRssWidgetSetting: <K extends keyof RssWidgetSettings>(key: K, value: RssWidgetSettings[K]) => void;
+  changeRssWidgetSettings: (settings: Partial<RssWidgetSettings>) => void;
   changeSearchProvider: (providerId: SearchProviderId) => void;
   changeSearchWidgetSetting: <K extends keyof SearchWidgetSettings>(key: K, value: SearchWidgetSettings[K]) => void;
   changeShortcutGridWidgetSetting: <K extends keyof ShortcutGridWidgetSettings>(
@@ -39,7 +43,6 @@ export type CanvasWidgetController = {
   dispatchDropAction: (action: DropAction) => void;
   gridRef: RefObject<HTMLElement | null>;
   hasOverlayOpen: boolean;
-  openEditFolderDialog: (folder: ResolvedFolder) => void;
   openEditShortcutDialog: (shortcut: Shortcut, folderId?: string | null) => void;
   setActiveFolderId: (folderId: string | null) => void;
   setActiveShortcutPage: (pageIndex: number | ((current: number) => number)) => void;
@@ -75,6 +78,7 @@ export function CanvasWidgetHost({
   const searchWidget = tabState.canvas.widgets.search;
   const weatherWidget = tabState.canvas.widgets.weather;
   const dateTimeWidget = tabState.canvas.widgets.dateTime;
+  const rssWidget = tabState.canvas.widgets.rss;
   const searchPlacement = resolveResponsiveDefaultWidgetPlacement("search", searchWidget.placement, canvasMetrics);
   const shortcutGridPlacement = resolveResponsiveDefaultWidgetPlacement(
     "shortcutGrid",
@@ -83,6 +87,7 @@ export function CanvasWidgetHost({
   );
   const weatherPlacement = resolveResponsiveDefaultWidgetPlacement("weather", weatherWidget.placement, canvasMetrics);
   const dateTimePlacement = resolveResponsiveDefaultWidgetPlacement("dateTime", dateTimeWidget.placement, canvasMetrics);
+  const rssPlacement = resolveResponsiveDefaultWidgetPlacement("rss", rssWidget.placement, canvasMetrics);
 
   useEffect(() => {
     if (!contextMenu) {
@@ -171,6 +176,20 @@ export function CanvasWidgetHost({
         </WidgetFrame>
 
         <WidgetFrame
+          editMode={isCanvasEditMode}
+          enabled={rssWidget.enabled}
+          label="Snap Feed Widget"
+          metrics={canvasMetrics}
+          onMove={(placement) => controller.updateWidgetPlacement("rss", placement, canvasMetrics)}
+          onResize={(placement) => controller.updateWidgetPlacement("rss", placement, canvasMetrics)}
+          onWidgetContextMenu={openWidgetContextMenu}
+          placement={rssPlacement}
+          widgetId="rss"
+        >
+          <RssWidget settings={rssWidget.settings} />
+        </WidgetFrame>
+
+        <WidgetFrame
           centerSnapAxes={{ x: true, y: false }}
           editMode={isCanvasEditMode}
           enabled={shortcutGridWidget.enabled}
@@ -190,7 +209,6 @@ export function CanvasWidgetHost({
             hasOverlayOpen={controller.hasOverlayOpen}
             isCanvasEditMode={isCanvasEditMode}
             onClearOutgoingDrag={() => setOutgoingDragSource(null)}
-            onEditFolder={controller.openEditFolderDialog}
             onEditShortcut={controller.openEditShortcutDialog}
             onSetActiveFolderId={controller.setActiveFolderId}
             outgoingDragSource={outgoingDragSource}
@@ -210,6 +228,8 @@ export function CanvasWidgetHost({
           changeWeatherWidgetSetting={controller.changeWeatherWidgetSetting}
           changeWeatherWidgetSettings={controller.changeWeatherWidgetSettings}
           changeDateTimeWidgetSetting={controller.changeDateTimeWidgetSetting}
+          changeRssWidgetSetting={controller.changeRssWidgetSetting}
+          changeRssWidgetSettings={controller.changeRssWidgetSettings}
           close={() => setContextMenu(null)}
           menu={contextMenu}
           setWidgetEnabled={(widgetId, enabled) => controller.setWidgetEnabled(widgetId, enabled, canvasMetrics)}

--- a/src/ui/popup/PopupApp.tsx
+++ b/src/ui/popup/PopupApp.tsx
@@ -32,7 +32,8 @@ export function PopupApp() {
       })
     )
   );
-  const replaceState = useTabStore((state) => state.replaceState);
+  const hasHydrated = useTabStore((state) => state.hasHydrated);
+  const updateState = useTabStore((state) => state.updateState);
   const popupThemeId = usePopupThemeId(tabState.themeId);
   const theme = getThemePreset(popupThemeId);
   const { draft, message, setDraft, setMessage } = useCurrentTabShortcutDraft();
@@ -66,7 +67,12 @@ export function PopupApp() {
       return;
     }
 
-    replaceState(upsertShortcut(tabState, shortcut, draft));
+    if (!hasHydrated) {
+      setMessage("SnapTab is still loading. Try again in a moment.");
+      return;
+    }
+
+    updateState((state) => upsertShortcut(state, shortcut, draft));
     setMessage("Saved to SnapTab.");
     window.setTimeout(() => window.close(), 550);
   }
@@ -88,7 +94,7 @@ export function PopupApp() {
           onChangeDraft={setDraft}
           onSave={saveShortcut}
           onUploadIcon={(file) => void uploadShortcutIcon(file)}
-          saveLabel="Add"
+          saveLabel={hasHydrated ? "Add" : "Loading..."}
         />
       </section>
     </main>

--- a/src/ui/widgets/WidgetContextMenu.tsx
+++ b/src/ui/widgets/WidgetContextMenu.tsx
@@ -18,6 +18,7 @@ type WidgetContextMenuProps = {
     value: ShortcutGridWidgetSettings[K]
   ) => void;
   changeWeatherWidgetSetting: <K extends keyof WeatherWidgetSettings>(key: K, value: WeatherWidgetSettings[K]) => void;
+  changeWeatherWidgetSettings: (settings: Partial<WeatherWidgetSettings>) => void;
   close: () => void;
   menu: ContextMenuState;
   setWidgetEnabled: (widgetId: WidgetId, enabled: boolean) => void;
@@ -31,6 +32,7 @@ export function WidgetContextMenu({
   changeSearchWidgetSetting,
   changeShortcutGridWidgetSetting,
   changeWeatherWidgetSetting,
+  changeWeatherWidgetSettings,
   close,
   menu,
   setWidgetEnabled,
@@ -114,6 +116,7 @@ export function WidgetContextMenu({
         ) : (
           <WeatherWidgetContextMenu
             changeWeatherWidgetSetting={changeWeatherWidgetSetting}
+            changeWeatherWidgetSettings={changeWeatherWidgetSettings}
             setEnabled={(enabled) => setWidgetEnabled("weather", enabled)}
             weatherWidget={weatherWidget}
           />

--- a/src/ui/widgets/WidgetContextMenu.tsx
+++ b/src/ui/widgets/WidgetContextMenu.tsx
@@ -1,7 +1,8 @@
 import type { CSSProperties } from "react";
 import type { TabState } from "../../domain/tabState";
-import type { DateTimeWidgetSettings, SearchWidgetSettings, ShortcutGridWidgetSettings, WeatherWidgetSettings, WidgetId } from "../../domain/canvas";
+import type { DateTimeWidgetSettings, RssWidgetSettings, SearchWidgetSettings, ShortcutGridWidgetSettings, WeatherWidgetSettings, WidgetId } from "../../domain/canvas";
 import { DateTimeWidgetContextMenu } from "./date-time";
+import { RssWidgetContextMenu } from "./rss";
 import { SearchWidgetContextMenu } from "./search";
 import { ShortcutGridWidgetContextMenu } from "./shortcut-grid";
 import { WeatherWidgetContextMenu } from "./weather";
@@ -12,6 +13,8 @@ type ContextMenuState =
 
 type WidgetContextMenuProps = {
   changeDateTimeWidgetSetting: <K extends keyof DateTimeWidgetSettings>(key: K, value: DateTimeWidgetSettings[K]) => void;
+  changeRssWidgetSetting: <K extends keyof RssWidgetSettings>(key: K, value: RssWidgetSettings[K]) => void;
+  changeRssWidgetSettings: (settings: Partial<RssWidgetSettings>) => void;
   changeSearchWidgetSetting: <K extends keyof SearchWidgetSettings>(key: K, value: SearchWidgetSettings[K]) => void;
   changeShortcutGridWidgetSetting: <K extends keyof ShortcutGridWidgetSettings>(
     key: K,
@@ -29,6 +32,8 @@ export type { ContextMenuState };
 
 export function WidgetContextMenu({
   changeDateTimeWidgetSetting,
+  changeRssWidgetSetting,
+  changeRssWidgetSettings,
   changeSearchWidgetSetting,
   changeShortcutGridWidgetSetting,
   changeWeatherWidgetSetting,
@@ -43,6 +48,7 @@ export function WidgetContextMenu({
   const shortcutGridWidget = tabState.canvas.widgets.shortcutGrid;
   const weatherWidget = tabState.canvas.widgets.weather;
   const dateTimeWidget = tabState.canvas.widgets.dateTime;
+  const rssWidget = tabState.canvas.widgets.rss;
   const style = {
     "--context-menu-x": `${menu.x}px`,
     "--context-menu-y": `${menu.y}px`
@@ -94,6 +100,14 @@ export function WidgetContextMenu({
                 type="checkbox"
               />
             </label>
+            <label className="context-toggle-row">
+              <span>Snap Feed Widget</span>
+              <input
+                checked={rssWidget.enabled}
+                onChange={(event) => setWidgetEnabled("rss", event.target.checked)}
+                type="checkbox"
+              />
+            </label>
           </>
         ) : menu.widgetId === "search" ? (
           <SearchWidgetContextMenu
@@ -113,12 +127,19 @@ export function WidgetContextMenu({
             dateTimeWidget={dateTimeWidget}
             setEnabled={(enabled) => setWidgetEnabled("dateTime", enabled)}
           />
-        ) : (
+        ) : menu.widgetId === "weather" ? (
           <WeatherWidgetContextMenu
             changeWeatherWidgetSetting={changeWeatherWidgetSetting}
             changeWeatherWidgetSettings={changeWeatherWidgetSettings}
             setEnabled={(enabled) => setWidgetEnabled("weather", enabled)}
             weatherWidget={weatherWidget}
+          />
+        ) : (
+          <RssWidgetContextMenu
+            changeRssWidgetSetting={changeRssWidgetSetting}
+            changeRssWidgetSettings={changeRssWidgetSettings}
+            rssWidget={rssWidget}
+            setEnabled={(enabled) => setWidgetEnabled("rss", enabled)}
           />
         )}
       </section>

--- a/src/ui/widgets/date-time/DateTimeWidget.tsx
+++ b/src/ui/widgets/date-time/DateTimeWidget.tsx
@@ -55,9 +55,9 @@ function ClockView({
   if (settings.clockMode === "verticalClock") {
     return (
       <div className="date-time-vertical" aria-label={timeParts.accessibleLabel}>
-        <strong style={{ color: settings.hourColor }}>{timeParts.hour}</strong>
-        <strong style={{ color: settings.minuteColor }}>{timeParts.minute}</strong>
-        {settings.showSeconds ? <strong style={{ color: settings.secondColor }}>{timeParts.second}</strong> : null}
+        <strong style={{ color: settings.hourColor }}><span className="date-time-vertical-digit">{timeParts.hour}</span></strong>
+        <strong style={{ color: settings.minuteColor }}><span className="date-time-vertical-digit">{timeParts.minute}</span></strong>
+        {settings.showSeconds ? <strong style={{ color: settings.secondColor }}><span className="date-time-vertical-digit">{timeParts.second}</span></strong> : null}
         {timeParts.period ? <span>{timeParts.period}</span> : null}
       </div>
     );

--- a/src/ui/widgets/date-time/DateTimeWidget.tsx
+++ b/src/ui/widgets/date-time/DateTimeWidget.tsx
@@ -46,8 +46,8 @@ function ClockView({
     const percent = getDayPercent(now);
     return (
       <div className="date-time-percentage" aria-label={`${percent}% of today complete`}>
-        <strong>{percent}%</strong>
-        <span>day complete</span>
+        <strong style={{ color: settings.hourColor }}>{percent}%</strong>
+        <span><span style={{ color: settings.minuteColor }}>day</span> <span style={{ color: settings.secondColor }}>complete</span></span>
       </div>
     );
   }
@@ -66,7 +66,15 @@ function ClockView({
   return (
     <div className="date-time-digital" aria-label={timeParts.accessibleLabel}>
       <strong>
-        {timeParts.hour}<span>:</span>{timeParts.minute}{settings.showSeconds ? <><span>:</span>{timeParts.second}</> : null}
+        <span className="date-time-part" style={{ color: settings.hourColor }}>{timeParts.hour}</span>
+        <span>:</span>
+        <span className="date-time-part" style={{ color: settings.minuteColor }}>{timeParts.minute}</span>
+        {settings.showSeconds ? (
+          <>
+            <span>:</span>
+            <span className="date-time-part" style={{ color: settings.secondColor }}>{timeParts.second}</span>
+          </>
+        ) : null}
       </strong>
       {timeParts.period ? <span>{timeParts.period}</span> : null}
     </div>

--- a/src/ui/widgets/date-time/DateTimeWidgetContextMenu.tsx
+++ b/src/ui/widgets/date-time/DateTimeWidgetContextMenu.tsx
@@ -71,6 +71,34 @@ export function DateTimeWidgetContextMenu({
         />
       </label>
 
+      <div className="date-time-color-row" role="group" aria-label="Clock colours">
+        <span>Colours</span>
+        <label>
+          <span>Hour</span>
+          <input
+            value={settings.hourColor}
+            onChange={(event) => changeDateTimeWidgetSetting("hourColor", event.target.value)}
+            type="color"
+          />
+        </label>
+        <label>
+          <span>Minute</span>
+          <input
+            value={settings.minuteColor}
+            onChange={(event) => changeDateTimeWidgetSetting("minuteColor", event.target.value)}
+            type="color"
+          />
+        </label>
+        <label>
+          <span>Second</span>
+          <input
+            value={settings.secondColor}
+            onChange={(event) => changeDateTimeWidgetSetting("secondColor", event.target.value)}
+            type="color"
+          />
+        </label>
+      </div>
+
       <label>
         <span>Date mode</span>
         <select

--- a/src/ui/widgets/date-time/DateTimeWidgetContextMenu.tsx
+++ b/src/ui/widgets/date-time/DateTimeWidgetContextMenu.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import type {
   DateTimeClockMode,
   DateTimeDateMode,
@@ -15,12 +16,39 @@ type DateTimeWidgetContextMenuProps = {
   setEnabled: (enabled: boolean) => void;
 };
 
+type ColorSettingKey = "hourColor" | "minuteColor" | "secondColor";
+
+const clockColorSettings: Array<{ key: ColorSettingKey; label: string }> = [
+  { key: "hourColor", label: "Hour" },
+  { key: "minuteColor", label: "Minute" },
+  { key: "secondColor", label: "Second" }
+];
+
 export function DateTimeWidgetContextMenu({
   changeDateTimeWidgetSetting,
   dateTimeWidget,
   setEnabled
 }: DateTimeWidgetContextMenuProps) {
   const settings = dateTimeWidget.settings;
+  const colorInputRef = useRef<HTMLInputElement>(null);
+  const activeColorSettingRef = useRef<ColorSettingKey>("hourColor");
+
+  function openColorPicker(key: ColorSettingKey) {
+    const input = colorInputRef.current;
+
+    activeColorSettingRef.current = key;
+    if (!input) {
+      return;
+    }
+
+    input.blur();
+    input.value = settings[key];
+    input.click();
+  }
+
+  function changeActiveColor(value: string) {
+    changeDateTimeWidgetSetting(activeColorSettingRef.current, value);
+  }
 
   return (
     <>
@@ -73,30 +101,27 @@ export function DateTimeWidgetContextMenu({
 
       <div className="date-time-color-row" role="group" aria-label="Clock colours">
         <span>Colours</span>
-        <label>
-          <span>Hour</span>
-          <input
-            value={settings.hourColor}
-            onChange={(event) => changeDateTimeWidgetSetting("hourColor", event.target.value)}
-            type="color"
-          />
-        </label>
-        <label>
-          <span>Minute</span>
-          <input
-            value={settings.minuteColor}
-            onChange={(event) => changeDateTimeWidgetSetting("minuteColor", event.target.value)}
-            type="color"
-          />
-        </label>
-        <label>
-          <span>Second</span>
-          <input
-            value={settings.secondColor}
-            onChange={(event) => changeDateTimeWidgetSetting("secondColor", event.target.value)}
-            type="color"
-          />
-        </label>
+        {clockColorSettings.map((colorSetting) => (
+          <button
+            aria-label={`Choose ${colorSetting.label.toLowerCase()} colour`}
+            className="date-time-color-button"
+            key={colorSetting.key}
+            onClick={() => openColorPicker(colorSetting.key)}
+            type="button"
+          >
+            <span>{colorSetting.label}</span>
+            <span className="date-time-color-swatch" style={{ backgroundColor: settings[colorSetting.key] }} />
+          </button>
+        ))}
+        <input
+          aria-hidden="true"
+          className="date-time-shared-color-input"
+          ref={colorInputRef}
+          tabIndex={-1}
+          type="color"
+          defaultValue={settings.hourColor}
+          onInput={(event) => changeActiveColor(event.currentTarget.value)}
+        />
       </div>
 
       <label>

--- a/src/ui/widgets/date-time/date-time-widget.css
+++ b/src/ui/widgets/date-time/date-time-widget.css
@@ -96,23 +96,35 @@
   align-items: center;
   justify-content: start;
   gap: clamp(8px, 4%, 14px);
+  min-width: 0;
 }
 
 .date-time-vertical strong {
+  box-sizing: border-box;
   display: grid;
+  width: 100%;
   min-width: 0;
   max-width: 100%;
   place-items: center;
-  overflow: visible;
+  overflow: hidden;
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.08);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
-  font-size: clamp(24px, min(21cqw, 42cqh), 92px);
+  font-size: clamp(22px, min(14cqw, 38cqh), 82px);
   font-variant-numeric: tabular-nums;
   font-weight: 950;
   letter-spacing: -0.015em;
   line-height: 1;
   padding: 8px clamp(8px, 2cqw, 14px);
+  text-align: center;
+}
+
+.date-time-vertical-digit {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  font-size: inherit;
+  line-height: 1;
   text-align: center;
 }
 
@@ -137,21 +149,38 @@
   font-weight: 800;
 }
 
-.widget-context-menu .date-time-color-row label {
+.widget-context-menu .date-time-color-button {
   display: grid;
   gap: 6px;
   justify-items: center;
   border-radius: 12px;
+  border: 0;
   background: rgba(255, 255, 255, 0.05);
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
   padding: 8px 6px;
 }
 
-.widget-context-menu .date-time-color-row input[type="color"] {
+.widget-context-menu .date-time-color-button:focus-visible {
+  outline: 2px solid var(--theme-accent, #7dd3fc);
+  outline-offset: 2px;
+}
+
+.date-time-color-swatch {
   width: 100%;
   height: 34px;
   border: 1px solid var(--theme-border, rgba(255, 255, 255, 0.16));
   border-radius: 10px;
-  background: transparent;
-  cursor: pointer;
   padding: 2px;
+}
+
+.date-time-shared-color-input {
+  position: fixed;
+  left: -100vw;
+  top: -100vh;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
 }

--- a/src/ui/widgets/date-time/date-time-widget.css
+++ b/src/ui/widgets/date-time/date-time-widget.css
@@ -1,5 +1,5 @@
 .date-time-widget {
-  container-type: inline-size;
+  container-type: size;
   display: grid;
   width: 100%;
   height: 100%;
@@ -20,7 +20,7 @@
 .date-time-digital strong {
   display: inline-block;
   color: #ffffff;
-  font-size: clamp(36px, 12vw, 78px);
+  font-size: clamp(36px, min(20cqw, 46cqh), 116px);
   font-weight: 950;
   letter-spacing: -0.06em;
   line-height: 0.92;
@@ -33,10 +33,14 @@
   margin: 0 0.03em;
 }
 
+.date-time-digital strong .date-time-part {
+  margin: 0;
+}
+
 .date-time-digital > span,
 .date-time-vertical > span {
   color: var(--theme-muted-text, rgba(226, 232, 240, 0.78));
-  font-size: clamp(12px, 2vw, 16px);
+  font-size: clamp(12px, min(4cqw, 10cqh), 22px);
   font-weight: 950;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -51,7 +55,7 @@
 .date-time-date-group span {
   overflow: hidden;
   color: var(--theme-muted-text, rgba(226, 232, 240, 0.82));
-  font-size: clamp(13px, 2.2vw, 18px);
+  font-size: clamp(13px, min(4.4cqw, 10cqh), 24px);
   font-weight: 850;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -59,7 +63,7 @@
 
 .date-time-date-group small {
   color: var(--theme-muted-text, rgba(226, 232, 240, 0.62));
-  font-size: 12px;
+  font-size: clamp(12px, min(3.4cqw, 7cqh), 18px);
   font-weight: 900;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -72,7 +76,7 @@
 
 .date-time-percentage strong {
   color: #ffffff;
-  font-size: clamp(42px, 13vw, 86px);
+  font-size: clamp(42px, min(22cqw, 48cqh), 124px);
   font-weight: 950;
   letter-spacing: -0.08em;
   line-height: 0.92;
@@ -80,7 +84,7 @@
 
 .date-time-percentage span {
   color: var(--theme-muted-text, rgba(226, 232, 240, 0.78));
-  font-size: clamp(12px, 2vw, 16px);
+  font-size: clamp(12px, min(4cqw, 10cqh), 22px);
   font-weight: 900;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -99,19 +103,55 @@
   min-width: 0;
   max-width: 100%;
   place-items: center;
-  overflow: hidden;
+  overflow: visible;
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.08);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
-  font-size: clamp(24px, 26cqw, 58px);
+  font-size: clamp(24px, min(21cqw, 42cqh), 92px);
+  font-variant-numeric: tabular-nums;
   font-weight: 950;
-  letter-spacing: -0.03em;
+  letter-spacing: -0.015em;
   line-height: 1;
-  padding: 8px 6px;
+  padding: 8px clamp(8px, 2cqw, 14px);
   text-align: center;
 }
 
 .date-time-vertical > span {
   align-self: end;
   padding-bottom: 8px;
+}
+
+.date-time-color-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  border-radius: 16px;
+  background: var(--theme-settings-card-bg, rgba(255, 255, 255, 0.06));
+  padding: 10px 12px;
+}
+
+.date-time-color-row > span {
+  grid-column: 1 / -1;
+  color: var(--theme-muted-text, rgba(241, 245, 249, 0.86));
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.widget-context-menu .date-time-color-row label {
+  display: grid;
+  gap: 6px;
+  justify-items: center;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.05);
+  padding: 8px 6px;
+}
+
+.widget-context-menu .date-time-color-row input[type="color"] {
+  width: 100%;
+  height: 34px;
+  border: 1px solid var(--theme-border, rgba(255, 255, 255, 0.16));
+  border-radius: 10px;
+  background: transparent;
+  cursor: pointer;
+  padding: 2px;
 }

--- a/src/ui/widgets/rss/RssWidget.tsx
+++ b/src/ui/widgets/rss/RssWidget.tsx
@@ -1,0 +1,228 @@
+import { useEffect, useRef, useState, type CSSProperties } from "react";
+import { AlertTriangle, LoaderCircle, RefreshCw, Rss } from "lucide-react";
+import type { RssWidgetSettings } from "../../../domain/canvas";
+import type { RssItem } from "../../../domain/rss";
+import { getWidgetSurfaceStyle } from "../widgetSurface";
+import { fetchRssItems, type RssFeedFailure } from "./rssService";
+
+type RssWidgetProps = {
+  settings: RssWidgetSettings;
+};
+
+type RssItemVisualProps = {
+  displayMode: RssWidgetSettings["displayMode"];
+  feedUrl: string;
+  item: RssItem;
+};
+
+type RssStatus =
+  | { type: "empty" }
+  | { type: "loading" }
+  | { type: "ready"; items: RssItem[]; failures: RssFeedFailure[] }
+  | { type: "error"; failures: RssFeedFailure[] };
+
+export function RssWidget({ settings }: RssWidgetProps) {
+  const [status, setStatus] = useState<RssStatus>(() => (settings.feeds.length === 0 ? { type: "empty" } : { type: "loading" }));
+  const [refreshNonce, setRefreshNonce] = useState(0);
+  const forceRefreshRef = useRef(false);
+  const surfaceStyle = getRssSurfaceStyle(settings);
+
+  function refreshFeeds() {
+    forceRefreshRef.current = true;
+    setRefreshNonce((current) => current + 1);
+  }
+
+  useEffect(() => {
+    if (settings.feeds.length === 0) {
+      setStatus({ type: "empty" });
+      return;
+    }
+
+    const controller = new AbortController();
+    const forceRefresh = forceRefreshRef.current;
+    forceRefreshRef.current = false;
+    setStatus({ type: "loading" });
+    fetchRssItems(settings, controller.signal, { forceRefresh })
+      .then((result) => {
+        if (result.items.length === 0 && result.failures.length > 0) {
+          setStatus({ type: "error", failures: result.failures });
+          return;
+        }
+
+        setStatus({ type: "ready", items: result.items, failures: result.failures });
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        setStatus({
+          type: "error",
+          failures: [{ feedId: "rss", title: "Snap Feed", message: error instanceof Error ? error.message : "Snap Feed unavailable." }]
+        });
+      });
+
+    return () => controller.abort();
+  }, [settings.feeds, settings.feedMode, settings.selectedFeedId, settings.maxItems, settings.maxItemsPerFeed, settings.refreshMinutes, refreshNonce]);
+
+  if (status.type === "empty") {
+    return (
+      <section className="rss-widget widget-surface rss-widget-empty" aria-label="Snap Feed empty" style={surfaceStyle}>
+        <Rss aria-hidden="true" />
+        <div>
+          <strong>No Snap Feed sources</strong>
+          <span>Add feeds from Edit Mode.</span>
+        </div>
+      </section>
+    );
+  }
+
+  if (status.type === "loading") {
+    return (
+      <section className="rss-widget widget-surface rss-widget-loading" aria-label="Snap Feed loading" style={surfaceStyle}>
+        <LoaderCircle aria-hidden="true" className="rss-spin" />
+        <span>Loading feeds</span>
+      </section>
+    );
+  }
+
+  if (status.type === "error") {
+    return (
+      <section className="rss-widget widget-surface rss-widget-error" aria-label="Snap Feed error" style={surfaceStyle}>
+        <AlertTriangle aria-hidden="true" />
+        <div>
+          <strong>Snap Feed unavailable</strong>
+          <span>{status.failures[0]?.message ?? "Feeds could not be loaded."}</span>
+        </div>
+      </section>
+    );
+  }
+
+  return <RssItemsView failures={status.failures} items={status.items} onRefresh={refreshFeeds} settings={settings} surfaceStyle={surfaceStyle} />;
+}
+
+function RssItemsView({
+  failures,
+  items,
+  onRefresh,
+  settings,
+  surfaceStyle
+}: {
+  failures: RssFeedFailure[];
+  items: RssItem[];
+  onRefresh: () => void;
+  settings: RssWidgetSettings;
+  surfaceStyle: CSSProperties;
+}) {
+  const mode = settings.displayMode;
+
+  return (
+    <section className={`rss-widget widget-surface rss-widget-${mode}`} aria-label="Snap Feed" style={surfaceStyle}>
+      <header className="rss-widget-header">
+        <span className="rss-widget-icon" aria-hidden="true"><Rss /></span>
+        <div className="rss-widget-title">
+          <strong>Snap Feed</strong>
+          <span>{settings.feedMode === "selected" ? getSelectedFeedTitle(settings) : `${settings.feeds.length} feeds`}</span>
+        </div>
+        <button className="rss-refresh-button" onClick={onRefresh} type="button">
+          <RefreshCw aria-hidden="true" />
+          <span>{failures.length} failed</span>
+        </button>
+      </header>
+
+      <div className="rss-items" role="list">
+        {items.map((item) => (
+          <a className="rss-item" href={item.link} key={item.id} rel="noreferrer" role="listitem" target="_blank">
+            <div className="rss-item-row">
+              <RssItemVisual displayMode={mode} feedUrl={getFeedUrl(settings, item.feedId)} item={item} />
+              <div className="rss-item-content">
+                <strong>{item.title}</strong>
+                <span className="rss-item-meta">
+                  {settings.showSource ? <span>{item.feedTitle}</span> : null}
+                  {formatRelativeTime(item.publishedAt) ? <time dateTime={item.publishedAt}>{formatRelativeTime(item.publishedAt)}</time> : null}
+                </span>
+                {mode === "expanded" && settings.showSnippet && item.snippet ? <small>{item.snippet}</small> : null}
+              </div>
+            </div>
+          </a>
+        ))}
+      </div>
+
+      {failures.length > 0 ? <p className="rss-failures">{failures.length} feed{failures.length === 1 ? "" : "s"} failed</p> : null}
+    </section>
+  );
+}
+
+function RssItemVisual({ displayMode, feedUrl, item }: RssItemVisualProps) {
+  const [failedImageUrl, setFailedImageUrl] = useState<string | null>(null);
+  const imageUrl = item.imageUrl && item.imageUrl !== failedImageUrl ? item.imageUrl : getFeedFaviconUrl(feedUrl);
+  const showImage = imageUrl && imageUrl !== failedImageUrl;
+
+  return (
+    <span className={`rss-item-visual rss-item-visual-${displayMode}`} aria-hidden="true">
+      {showImage ? (
+        <img alt="" src={imageUrl} onError={() => setFailedImageUrl(imageUrl)} />
+      ) : (
+        <span className="rss-item-initials">{getFeedInitials(item.feedTitle)}</span>
+      )}
+    </span>
+  );
+}
+
+function getSelectedFeedTitle(settings: RssWidgetSettings) {
+  return settings.feeds.find((feed) => feed.id === settings.selectedFeedId)?.title ?? "Selected feed";
+}
+
+function getFeedUrl(settings: RssWidgetSettings, feedId: string) {
+  return settings.feeds.find((feed) => feed.id === feedId)?.url ?? "";
+}
+
+function getFeedFaviconUrl(feedUrl: string): string | undefined {
+  try {
+    const hostname = new URL(feedUrl).hostname;
+    return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(hostname)}&sz=64`;
+  } catch {
+    return undefined;
+  }
+}
+
+function getFeedInitials(feedTitle: string): string {
+  const words = feedTitle.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) {
+    return "R";
+  }
+
+  const initials = words.length === 1 ? words[0].slice(0, 2) : `${words[0][0]}${words[1][0]}`;
+  return initials.toUpperCase();
+}
+
+function formatRelativeTime(value: string | undefined) {
+  if (!value) {
+    return null;
+  }
+
+  const elapsedMs = Date.now() - Date.parse(value);
+  if (!Number.isFinite(elapsedMs)) {
+    return null;
+  }
+
+  const minutes = Math.max(0, Math.floor(elapsedMs / 60_000));
+  if (minutes < 60) {
+    return `${minutes || 1}m`;
+  }
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${hours}h`;
+  }
+
+  return `${Math.floor(hours / 24)}d`;
+}
+
+function getRssSurfaceStyle(settings: RssWidgetSettings) {
+  return {
+    ...getWidgetSurfaceStyle(settings),
+    "--widget-padding": "clamp(12px, 7%, 18px)",
+    "--widget-radius": "24px"
+  } as CSSProperties;
+}

--- a/src/ui/widgets/rss/RssWidgetContextMenu.tsx
+++ b/src/ui/widgets/rss/RssWidgetContextMenu.tsx
@@ -1,0 +1,272 @@
+import { useRef, useState, type FormEvent } from "react";
+import type { RssDisplayMode, RssFeed, RssFeedMode, RssWidgetSettings, WidgetState } from "../../../domain/canvas";
+import { createRssFeedId, normalizeFeedUrl, parseOpmlFeeds, serializeOpmlFeeds } from "../../../domain/rss";
+import { RangeRow, WidgetVisualControls } from "../WidgetContextMenuControls";
+import { checkRssFeed } from "./rssService";
+
+type RssWidgetContextMenuProps = {
+  changeRssWidgetSetting: <K extends keyof RssWidgetSettings>(key: K, value: RssWidgetSettings[K]) => void;
+  changeRssWidgetSettings: (settings: Partial<RssWidgetSettings>) => void;
+  rssWidget: WidgetState<RssWidgetSettings>;
+  setEnabled: (enabled: boolean) => void;
+};
+
+type FeedCheckStatus =
+  | { state: "checking"; message: string }
+  | { state: "ok"; message: string }
+  | { state: "error"; message: string };
+
+export function RssWidgetContextMenu({
+  changeRssWidgetSetting,
+  changeRssWidgetSettings,
+  rssWidget,
+  setEnabled
+}: RssWidgetContextMenuProps) {
+  const importInputRef = useRef<HTMLInputElement>(null);
+  const [feedUrl, setFeedUrl] = useState("");
+  const [feedTitle, setFeedTitle] = useState("");
+  const [message, setMessage] = useState<string | null>(null);
+  const [feedStatuses, setFeedStatuses] = useState<Record<string, FeedCheckStatus>>({});
+  const importModeRef = useRef<"merge" | "replace">("merge");
+  const settings = rssWidget.settings;
+
+  function addFeed(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const url = normalizeFeedUrl(feedUrl);
+    if (!url) {
+      setMessage("Enter a valid RSS URL.");
+      return;
+    }
+
+    if (settings.feeds.some((feed) => normalizeFeedUrl(feed.url) === url)) {
+      setMessage("Feed already exists.");
+      return;
+    }
+
+    const nextFeed = {
+      id: createRssFeedId(url),
+      title: feedTitle.trim() || getFeedTitleFromUrl(url),
+      url
+    };
+    changeRssWidgetSettings({ feeds: [...settings.feeds, nextFeed], selectedFeedId: settings.selectedFeedId ?? nextFeed.id });
+    setFeedUrl("");
+    setFeedTitle("");
+    setMessage("Feed added. Checking feed...");
+    checkFeeds([nextFeed]);
+  }
+
+  function removeFeed(feedId: string) {
+    const feeds = settings.feeds.filter((feed) => feed.id !== feedId);
+    changeRssWidgetSettings({
+      feeds,
+      selectedFeedId: settings.selectedFeedId === feedId ? feeds[0]?.id ?? null : settings.selectedFeedId
+    });
+  }
+
+  async function importOpml(file: File | null, mode: "merge" | "replace") {
+    if (!file) {
+      return;
+    }
+
+    if (mode === "replace") {
+      const shouldReplace = window.confirm(
+        "Replace existing RSS feeds?\n\nThis will remove your current RSS feed list and replace it with feeds from the OPML file. Cached articles may be cleared."
+      );
+      if (!shouldReplace) {
+        setMessage("OPML replace cancelled.");
+        return;
+      }
+    }
+
+    try {
+      const importedFeeds = parseOpmlFeeds(await file.text());
+      const feeds = mode === "replace" ? importedFeeds : mergeFeeds(settings.feeds, importedFeeds);
+      if (mode === "replace") {
+        setFeedStatuses({});
+      }
+
+      changeRssWidgetSettings({ feeds, selectedFeedId: settings.selectedFeedId && feeds.some((feed) => feed.id === settings.selectedFeedId) ? settings.selectedFeedId : feeds[0]?.id ?? null });
+      setMessage(`${importedFeeds.length} feed${importedFeeds.length === 1 ? "" : "s"} imported. Checking feeds...`);
+      checkFeeds(importedFeeds);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Could not import OPML.");
+    } finally {
+      if (importInputRef.current) {
+        importInputRef.current.value = "";
+      }
+    }
+  }
+
+  function exportOpml() {
+    const blob = new Blob([serializeOpmlFeeds(settings.feeds)], { type: "text/x-opml+xml" });
+    const objectUrl = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = objectUrl;
+    link.download = `snaptab-rss-feeds-${new Date().toISOString().slice(0, 10)}.opml`;
+    link.click();
+    URL.revokeObjectURL(objectUrl);
+    setMessage("OPML exported.");
+  }
+
+  async function checkFeeds(feeds: RssFeed[]) {
+    if (feeds.length === 0) {
+      setMessage("No feeds to check.");
+      return;
+    }
+
+    setMessage(`Checking ${feeds.length} feed${feeds.length === 1 ? "" : "s"}...`);
+
+    setFeedStatuses((current) => ({
+      ...current,
+      ...Object.fromEntries(feeds.map((feed) => [feed.id, { state: "checking", message: "Checking..." } satisfies FeedCheckStatus]))
+    }));
+
+    const results = await Promise.all(feeds.map(async (feed) => ({ feed, result: await checkRssFeed(feed) })));
+    setFeedStatuses((current) => ({
+      ...current,
+      ...Object.fromEntries(
+        results.map(({ feed, result }) => [
+          feed.id,
+          result.ok
+            ? ({ state: "ok", message: "Reachable" } satisfies FeedCheckStatus)
+            : ({ state: "error", message: result.message } satisfies FeedCheckStatus)
+        ])
+      )
+    }));
+  }
+
+  return (
+    <>
+      <header className="widget-context-header">
+        <span>Widget</span>
+        <strong>Snap Feed</strong>
+      </header>
+      <label className="context-toggle-row">
+        <span>Enabled</span>
+        <input checked={rssWidget.enabled} onChange={(event) => setEnabled(event.target.checked)} type="checkbox" />
+      </label>
+
+      <form className="rss-context-card" onSubmit={addFeed}>
+        <label>
+          <span>Feed URL</span>
+          <input onChange={(event) => setFeedUrl(event.target.value)} placeholder="https://example.com/feed.xml" type="url" value={feedUrl} />
+        </label>
+        <label>
+          <span>Title</span>
+          <input onChange={(event) => setFeedTitle(event.target.value)} placeholder="Optional" type="text" value={feedTitle} />
+        </label>
+        <button type="submit">Add feed</button>
+        {message ? <p>{message}</p> : null}
+      </form>
+
+      {settings.feeds.length > 0 ? (
+        <div className="rss-context-feed-list" aria-label="RSS feeds">
+          {settings.feeds.map((feed) => (
+            <div className={`rss-context-feed rss-context-feed-${feedStatuses[feed.id]?.state ?? "unknown"}`} key={feed.id}>
+              <span>{feed.title}</span>
+              <small title={feedStatuses[feed.id]?.message}>{feedStatuses[feed.id]?.message ?? "Not checked"}</small>
+              <button onClick={() => removeFeed(feed.id)} type="button">Remove</button>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="rss-context-actions">
+        <button onClick={() => {
+          importModeRef.current = "merge";
+          importInputRef.current?.click();
+        }} type="button">Import OPML</button>
+        <button disabled={settings.feeds.length === 0} onClick={exportOpml} type="button">Export OPML</button>
+        <button onClick={() => {
+          importModeRef.current = "replace";
+          importInputRef.current?.click();
+        }} type="button">Replace OPML</button>
+        <button disabled={settings.feeds.length === 0} onClick={() => checkFeeds(settings.feeds)} type="button">Check feeds</button>
+        <input
+          accept=".opml,.xml,text/xml,application/xml"
+          className="rss-context-file-input"
+          onChange={(event) => importOpml(event.target.files?.[0] ?? null, importModeRef.current)}
+          ref={importInputRef}
+          type="file"
+        />
+      </div>
+
+      <label>
+        <span>Feed view</span>
+        <select value={settings.feedMode} onChange={(event) => changeRssWidgetSetting("feedMode", event.target.value as RssFeedMode)}>
+          <option value="all">All feeds</option>
+          <option value="selected">Selected feed</option>
+        </select>
+      </label>
+
+      {settings.feedMode === "selected" ? (
+        <label>
+          <span>Selected feed</span>
+          <select
+            value={settings.selectedFeedId ?? ""}
+            onChange={(event) => changeRssWidgetSetting("selectedFeedId", event.target.value || null)}
+          >
+            <option value="">Choose feed</option>
+            {settings.feeds.map((feed) => <option key={feed.id} value={feed.id}>{feed.title}</option>)}
+          </select>
+        </label>
+      ) : null}
+
+      <label>
+        <span>Display</span>
+        <select value={settings.displayMode} onChange={(event) => changeRssWidgetSetting("displayMode", event.target.value as RssDisplayMode)}>
+          <option value="compact">Compact</option>
+          <option value="standard">Standard</option>
+          <option value="expanded">Expanded</option>
+        </select>
+      </label>
+
+      <RangeRow label="Items" max={20} min={1} onChange={(value) => changeRssWidgetSetting("maxItems", value)} suffix="" value={settings.maxItems} />
+      {settings.feedMode === "all" ? (
+        <RangeRow
+          label="Items per feed"
+          max={10}
+          min={1}
+          onChange={(value) => changeRssWidgetSetting("maxItemsPerFeed", value)}
+          suffix=""
+          value={settings.maxItemsPerFeed}
+        />
+      ) : null}
+      <RangeRow label="Refresh" max={240} min={5} onChange={(value) => changeRssWidgetSetting("refreshMinutes", value)} suffix=" min" value={settings.refreshMinutes} />
+      <WidgetVisualControls visual={settings.visual} onChange={(visual) => changeRssWidgetSetting("visual", visual)} />
+
+      <label className="context-toggle-row">
+        <span>Show source</span>
+        <input checked={settings.showSource} onChange={(event) => changeRssWidgetSetting("showSource", event.target.checked)} type="checkbox" />
+      </label>
+      <label className="context-toggle-row">
+        <span>Show snippets</span>
+        <input checked={settings.showSnippet} onChange={(event) => changeRssWidgetSetting("showSnippet", event.target.checked)} type="checkbox" />
+      </label>
+    </>
+  );
+}
+
+function mergeFeeds(currentFeeds: RssWidgetSettings["feeds"], importedFeeds: RssWidgetSettings["feeds"]) {
+  const seenUrls = new Set(currentFeeds.map((feed) => normalizeFeedUrl(feed.url)).filter(Boolean));
+  return [
+    ...currentFeeds,
+    ...importedFeeds.filter((feed) => {
+      const url = normalizeFeedUrl(feed.url);
+      if (!url || seenUrls.has(url)) {
+        return false;
+      }
+
+      seenUrls.add(url);
+      return true;
+    })
+  ];
+}
+
+function getFeedTitleFromUrl(url: string) {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return "RSS Feed";
+  }
+}

--- a/src/ui/widgets/rss/index.ts
+++ b/src/ui/widgets/rss/index.ts
@@ -1,0 +1,2 @@
+export { RssWidget } from "./RssWidget";
+export { RssWidgetContextMenu } from "./RssWidgetContextMenu";

--- a/src/ui/widgets/rss/rss-widget.css
+++ b/src/ui/widgets/rss/rss-widget.css
@@ -1,0 +1,398 @@
+.rss-widget {
+  container-type: size;
+  display: grid;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  gap: clamp(8px, 4cqh, 14px);
+  color: var(--theme-text, #f8fafc);
+}
+
+.rss-widget-header {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: clamp(10px, 4cqw, 16px);
+}
+
+.rss-widget-icon {
+  display: grid;
+  width: clamp(34px, min(16cqw, 24cqh), 64px);
+  aspect-ratio: 1;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: clamp(14px, 6cqw, 24px);
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--theme-accent, #7dd3fc);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.16);
+}
+
+.rss-widget-icon svg {
+  width: 56%;
+  height: 56%;
+}
+
+.rss-widget-title {
+  display: grid;
+  min-width: 0;
+  flex: 1 1 auto;
+  gap: 2px;
+}
+
+.rss-refresh-button {
+  display: inline-flex;
+  min-width: 0;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--theme-muted-text, rgba(226, 232, 240, 0.82));
+  cursor: pointer;
+  font: inherit;
+  font-size: clamp(10px, min(3.2cqw, 5.6cqh), 13px);
+  font-weight: 900;
+  padding: 7px 9px;
+}
+
+.rss-refresh-button:hover,
+.rss-refresh-button:focus-visible {
+  background: rgba(255, 255, 255, 0.15);
+  color: #ffffff;
+  outline: 2px solid color-mix(in srgb, var(--theme-accent, #7dd3fc) 52%, transparent);
+  outline-offset: 2px;
+}
+
+.rss-refresh-button svg {
+  width: 14px;
+  height: 14px;
+}
+
+.rss-widget-header strong {
+  color: #ffffff;
+  font-size: clamp(18px, min(7cqw, 11cqh), 30px);
+  font-weight: 950;
+  letter-spacing: -0.04em;
+}
+
+.rss-widget-header span,
+.rss-item-meta,
+.rss-failures,
+.rss-widget-empty span,
+.rss-widget-loading span,
+.rss-widget-error span {
+  overflow: hidden;
+  color: var(--theme-muted-text, rgba(226, 232, 240, 0.78));
+  font-size: clamp(11px, min(3.5cqw, 6cqh), 16px);
+  font-weight: 800;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rss-items {
+  display: grid;
+  min-height: 0;
+  gap: clamp(6px, 2cqh, 10px);
+  overflow: auto;
+  padding-right: 4px;
+  scrollbar-color: color-mix(in srgb, var(--theme-accent, #7dd3fc) 42%, rgba(255, 255, 255, 0.2)) transparent;
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
+  mask-image: linear-gradient(to bottom, transparent 0, #000 12px, #000 calc(100% - 12px), transparent 100%);
+}
+
+.rss-items::-webkit-scrollbar {
+  width: 8px;
+}
+
+.rss-items::-webkit-scrollbar-track {
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.rss-items::-webkit-scrollbar-thumb {
+  border: 2px solid transparent;
+  border-radius: 999px;
+  background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--theme-accent, #7dd3fc) 56%, rgba(255, 255, 255, 0.18)),
+      rgba(255, 255, 255, 0.18)
+    )
+    border-box;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2);
+}
+
+.rss-items::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--theme-accent, #7dd3fc) 68%, rgba(255, 255, 255, 0.24)) border-box;
+}
+
+.rss-item {
+  display: block;
+  min-width: 0;
+  border-radius: clamp(12px, 4cqw, 18px);
+  background: rgba(255, 255, 255, 0.07);
+  color: inherit;
+  padding: clamp(8px, min(3cqw, 4cqh), 12px);
+  text-decoration: none;
+}
+
+.rss-item:hover,
+.rss-item:focus-visible {
+  background: rgba(255, 255, 255, 0.12);
+  outline: 2px solid color-mix(in srgb, var(--theme-accent, #7dd3fc) 56%, transparent);
+  outline-offset: 2px;
+}
+
+.rss-item-row {
+  display: flex;
+  min-width: 0;
+  align-items: flex-start;
+  gap: clamp(10px, 3cqw, 12px);
+}
+
+.rss-item-content {
+  display: grid;
+  min-width: 0;
+  flex: 1 1 auto;
+  gap: 3px;
+}
+
+.rss-item-visual {
+  display: grid;
+  flex: 0 0 auto;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.1);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+}
+
+.rss-item-visual-compact {
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+}
+
+.rss-item-visual-standard {
+  width: 40px;
+  height: 40px;
+}
+
+.rss-item-visual-expanded {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+}
+
+.rss-item-visual img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.rss-item-initials {
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 12px;
+  font-weight: 900;
+  letter-spacing: 0.04em;
+}
+
+.rss-item-visual-expanded .rss-item-initials {
+  font-size: 14px;
+}
+
+.rss-item-content strong {
+  overflow: hidden;
+  color: #ffffff;
+  font-size: clamp(12px, min(4cqw, 6.8cqh), 18px);
+  font-weight: 900;
+  line-height: 1.15;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rss-item-meta {
+  display: flex;
+  min-width: 0;
+  gap: 8px;
+}
+
+.rss-item-content small {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--theme-muted-text, rgba(226, 232, 240, 0.72));
+  font-size: clamp(11px, min(3.4cqw, 5.8cqh), 15px);
+  font-weight: 700;
+  line-height: 1.3;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.rss-widget-compact .rss-widget-header {
+  gap: 8px;
+}
+
+.rss-widget-compact .rss-widget-title span,
+.rss-widget-compact .rss-refresh-button span {
+  display: none;
+}
+
+.rss-widget-compact .rss-item small,
+.rss-widget-compact .rss-item-meta time {
+  display: none;
+}
+
+.rss-widget-compact .rss-item {
+  padding: 8px;
+}
+
+.rss-widget-empty,
+.rss-widget-loading,
+.rss-widget-error {
+  grid-template-columns: auto 1fr;
+  align-content: center;
+  align-items: center;
+}
+
+.rss-widget-empty > svg,
+.rss-widget-loading svg,
+.rss-widget-error > svg {
+  width: clamp(28px, min(10cqw, 18cqh), 48px);
+  height: clamp(28px, min(10cqw, 18cqh), 48px);
+  color: var(--theme-accent, #7dd3fc);
+}
+
+.rss-widget-empty strong,
+.rss-widget-error strong {
+  display: block;
+  color: #ffffff;
+  font-size: clamp(13px, min(4.4cqw, 7cqh), 20px);
+  font-weight: 950;
+}
+
+.rss-failures {
+  margin: 0;
+}
+
+.rss-spin {
+  animation: rss-spin 0.9s linear infinite;
+}
+
+.rss-context-card,
+.rss-context-feed-list,
+.rss-context-actions {
+  display: grid;
+  gap: 8px;
+  border-radius: 16px;
+  background: var(--theme-settings-card-bg, rgba(255, 255, 255, 0.06));
+  padding: 10px 12px;
+}
+
+.rss-context-card label {
+  padding: 0;
+  background: transparent;
+}
+
+.rss-context-card input {
+  width: 100%;
+  height: 36px;
+  border: 1px solid var(--theme-border, rgba(255, 255, 255, 0.16));
+  border-radius: 12px;
+  background: var(--theme-input-bg, rgba(15, 23, 42, 0.92));
+  color: var(--theme-input-text, #f8fafc);
+  padding: 0 10px;
+}
+
+.rss-context-card button,
+.rss-context-actions button,
+.rss-context-feed button {
+  min-height: 34px;
+  border: 0;
+  border-radius: 12px;
+  background: var(--theme-accent, #7dd3fc);
+  color: #082f49;
+  cursor: pointer;
+  font-weight: 950;
+  padding: 0 10px;
+}
+
+.rss-context-actions {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.rss-context-actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.rss-context-card p {
+  margin: 0;
+  color: var(--theme-muted-text, rgba(226, 232, 240, 0.78));
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.rss-context-feed {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 8px;
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  padding: 6px;
+}
+
+.rss-context-feed span {
+  overflow: hidden;
+  color: var(--theme-muted-text, rgba(241, 245, 249, 0.88));
+  font-size: 12px;
+  font-weight: 900;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rss-context-feed small {
+  max-width: 92px;
+  overflow: hidden;
+  color: var(--theme-muted-text, rgba(241, 245, 249, 0.72));
+  font-size: 11px;
+  font-weight: 900;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rss-context-feed-ok {
+  border-color: color-mix(in srgb, #86efac 42%, transparent);
+  background: color-mix(in srgb, #86efac 10%, transparent);
+}
+
+.rss-context-feed-ok span,
+.rss-context-feed-ok small {
+  color: #bbf7d0;
+}
+
+.rss-context-feed-error {
+  border-color: color-mix(in srgb, #fca5a5 48%, transparent);
+  background: color-mix(in srgb, #fca5a5 10%, transparent);
+}
+
+.rss-context-feed-error span,
+.rss-context-feed-error small {
+  color: #fecaca;
+}
+
+.rss-context-feed-checking {
+  border-color: color-mix(in srgb, var(--theme-accent, #7dd3fc) 36%, transparent);
+}
+
+.rss-context-file-input {
+  display: none;
+}
+
+@keyframes rss-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/ui/widgets/rss/rssService.ts
+++ b/src/ui/widgets/rss/rssService.ts
@@ -1,0 +1,243 @@
+import type { RssFeed, RssWidgetSettings } from "../../../domain/canvas";
+import { dedupeRssItems, parseRssXml, type RssFeedCache, type RssItem } from "../../../domain/rss";
+
+export type RssFeedFailure = {
+  feedId: string;
+  title: string;
+  message: string;
+};
+
+export type RssFetchResult = {
+  items: RssItem[];
+  failures: RssFeedFailure[];
+};
+
+type RssFetchOptions = {
+  forceRefresh?: boolean;
+};
+
+const cache = new Map<string, RssFeedCache>();
+const persistentRssCacheKey = "snapTabRssCache";
+
+type FeedFetchResponse = {
+  ok: boolean;
+  status: number;
+  text?: string;
+  error?: string;
+};
+
+type SendRuntimeMessage = (message: unknown, callback: (response: unknown) => void) => void;
+
+export async function fetchRssItems(settings: RssWidgetSettings, signal?: AbortSignal, options: RssFetchOptions = {}): Promise<RssFetchResult> {
+  const feeds = getActiveFeeds(settings);
+  if (feeds.length === 0) {
+    return { items: [], failures: [] };
+  }
+
+  const results = await Promise.all(feeds.map((feed) => fetchFeedItems(feed, settings.refreshMinutes, signal, options)));
+  const maxItemsPerFeed = settings.feedMode === "selected" ? settings.maxItems : settings.maxItemsPerFeed;
+  const items = dedupeRssItems(results.flatMap((result) => limitFeedItems(result.items, maxItemsPerFeed)))
+    .sort((first, second) => getItemTime(second) - getItemTime(first))
+    .slice(0, settings.maxItems);
+  const failures = results.flatMap((result) => result.failure ? [result.failure] : []);
+
+  return { items, failures };
+}
+
+export async function checkRssFeed(feed: RssFeed, signal?: AbortSignal): Promise<{ ok: true } | { ok: false; message: string }> {
+  try {
+    parseRssXml(await fetchFeedText(feed.url, signal), feed);
+    return { ok: true };
+  } catch (error) {
+    if (signal?.aborted) {
+      return { ok: false, message: "Check cancelled." };
+    }
+
+    return { ok: false, message: error instanceof Error ? error.message : "Feed unavailable." };
+  }
+}
+
+function limitFeedItems(items: RssItem[], maxItemsPerFeed: number) {
+  return [...items].sort((first, second) => getItemTime(second) - getItemTime(first)).slice(0, maxItemsPerFeed);
+}
+
+async function fetchFeedItems(
+  feed: RssFeed,
+  refreshMinutes: number,
+  signal?: AbortSignal,
+  options: RssFetchOptions = {}
+): Promise<{ items: RssItem[]; failure: RssFeedFailure | null }> {
+  const cached = await getCachedFeed(feed.url);
+  if (!options.forceRefresh && cached && isFresh(cached, refreshMinutes)) {
+    return { items: withFeedMetadata(cached.items, feed), failure: null };
+  }
+
+  try {
+    const xmlText = await fetchFeedText(feed.url, signal);
+    const parsed = parseRssXml(xmlText, feed);
+    const now = new Date().toISOString();
+    const nextCache: RssFeedCache = {
+      feedUrl: feed.url,
+      items: parsed.items,
+      lastFetchedAt: now,
+      lastSuccessAt: now
+    };
+
+    cache.set(feed.url, nextCache);
+    await writePersistentCache(feed.url, nextCache);
+    return { items: withFeedMetadata(parsed.items, { ...feed, title: parsed.title }), failure: null };
+  } catch (error) {
+    if (signal?.aborted) {
+      return { items: [], failure: null };
+    }
+
+    const message = error instanceof Error ? error.message : "Feed unavailable.";
+    const failedCache: RssFeedCache = {
+      feedUrl: feed.url,
+      items: cached?.items ?? [],
+      lastFetchedAt: new Date().toISOString(),
+      ...(cached?.lastSuccessAt ? { lastSuccessAt: cached.lastSuccessAt } : {}),
+      lastError: message
+    };
+    cache.set(feed.url, failedCache);
+    await writePersistentCache(feed.url, failedCache);
+
+    return {
+      items: cached ? withFeedMetadata(cached.items, feed) : [],
+      failure: { feedId: feed.id, title: feed.title, message }
+    };
+  }
+}
+
+async function fetchFeedText(url: string, signal?: AbortSignal): Promise<string> {
+  const sendMessage = typeof chrome !== "undefined" ? chrome.runtime?.sendMessage : undefined;
+  if (sendMessage) {
+    return fetchFeedTextViaBackground(url, signal, sendMessage);
+  }
+
+  const response = await fetch(url, { signal });
+  if (!response.ok) {
+    throw new Error(`Feed returned ${response.status}.`);
+  }
+
+  return response.text();
+}
+
+function fetchFeedTextViaBackground(
+  url: string,
+  signal: AbortSignal | undefined,
+  sendMessage: SendRuntimeMessage
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException("Aborted", "AbortError"));
+      return;
+    }
+
+    const abort = () => reject(new DOMException("Aborted", "AbortError"));
+    signal?.addEventListener("abort", abort, { once: true });
+    sendMessage({ type: "SNAPTAB_FETCH_RSS_FEED", url }, (response) => {
+      signal?.removeEventListener("abort", abort);
+      const lastError = chrome?.runtime?.lastError?.message;
+      if (lastError) {
+        reject(new Error(lastError));
+        return;
+      }
+
+      if (!isFeedFetchResponse(response)) {
+        reject(new Error("Feed fetch failed."));
+        return;
+      }
+
+      if (!response.ok) {
+        reject(new Error(response.error ?? `Feed returned ${response.status}.`));
+        return;
+      }
+
+      resolve(response.text ?? "");
+    });
+  });
+}
+
+function getActiveFeeds(settings: RssWidgetSettings) {
+  if (settings.feedMode !== "selected") {
+    return settings.feeds;
+  }
+
+  return settings.feeds.filter((feed) => feed.id === settings.selectedFeedId);
+}
+
+function withFeedMetadata(items: RssItem[], feed: RssFeed) {
+  return items.map((item) => ({ ...item, feedId: feed.id, feedTitle: feed.title }));
+}
+
+function isFresh(cached: RssFeedCache, refreshMinutes: number) {
+  return Date.now() - Date.parse(cached.lastFetchedAt) < refreshMinutes * 60_000;
+}
+
+async function getCachedFeed(feedUrl: string): Promise<RssFeedCache | null> {
+  const memory = cache.get(feedUrl);
+  if (memory) {
+    return memory;
+  }
+
+  const persistentCache = await readPersistentCache();
+  const persistent = persistentCache[feedUrl];
+  if (isRssFeedCache(persistent)) {
+    cache.set(feedUrl, persistent);
+    return persistent;
+  }
+
+  return null;
+}
+
+async function readPersistentCache(): Promise<Record<string, unknown>> {
+  const chromeLocal = typeof chrome !== "undefined" ? chrome.storage?.local : undefined;
+  if (chromeLocal) {
+    return new Promise((resolve) => {
+      chromeLocal.get([persistentRssCacheKey], (items) => {
+        resolve(isRecord(items[persistentRssCacheKey]) ? (items[persistentRssCacheKey] as Record<string, unknown>) : {});
+      });
+    });
+  }
+
+  try {
+    const value = window.localStorage.getItem(persistentRssCacheKey);
+    const parsed = value ? (JSON.parse(value) as unknown) : null;
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+async function writePersistentCache(feedUrl: string, value: RssFeedCache) {
+  const nextCache = { ...(await readPersistentCache()), [feedUrl]: value };
+  const chromeLocal = typeof chrome !== "undefined" ? chrome.storage?.local : undefined;
+  if (chromeLocal) {
+    await new Promise<void>((resolve) => chromeLocal.set({ [persistentRssCacheKey]: nextCache }, () => resolve()));
+    return;
+  }
+
+  window.localStorage.setItem(persistentRssCacheKey, JSON.stringify(nextCache));
+}
+
+function getItemTime(item: RssItem) {
+  return item.publishedAt ? Date.parse(item.publishedAt) || 0 : 0;
+}
+
+function isRssFeedCache(value: unknown): value is RssFeedCache {
+  return (
+    isRecord(value) &&
+    typeof value.feedUrl === "string" &&
+    Array.isArray(value.items) &&
+    typeof value.lastFetchedAt === "string"
+  );
+}
+
+function isFeedFetchResponse(value: unknown): value is FeedFetchResponse {
+  return isRecord(value) && typeof value.ok === "boolean" && typeof value.status === "number";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/ui/widgets/shortcut-grid/FolderPanel.tsx
+++ b/src/ui/widgets/shortcut-grid/FolderPanel.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useCallback, useEffect, type DragEvent } from "react";
+import { Pencil } from "lucide-react";
 import type { DropAction } from "../../../domain/dropActions";
 import { openShortcutUrl } from "../../../infrastructure/openShortcutUrl";
 import { type ResolvedFolder } from "../../../domain/tabOperations";
@@ -14,8 +15,8 @@ type FolderPanelProps = {
   activeShortcutPageIndex: number;
   dispatchDropAction: (action: DropAction) => void;
   onClose: () => void;
-  onEditFolder: (folder: ResolvedFolder) => void;
   onEditShortcut: (shortcut: Shortcut) => void;
+  onRenameFolder: (folderId: string, title: string) => void;
   onStartOutgoingDrag: (source: DragSource) => void;
   tabState: TabState;
 };
@@ -27,8 +28,8 @@ export function FolderPanel({
   activeShortcutPageIndex,
   dispatchDropAction,
   onClose,
-  onEditFolder,
   onEditShortcut,
+  onRenameFolder,
   onStartOutgoingDrag,
   tabState
 }: FolderPanelProps) {
@@ -37,6 +38,8 @@ export function FolderPanel({
   const [dropPosition, setDropPosition] = useState<"left" | "right">("left");
   const [overlayPos, setOverlayPos] = useState<{ x: number; y: number } | null>(null);
   const [overlayOffset, setOverlayOffset] = useState({ x: 40, y: 40 });
+  const [isRenamingFolder, setIsRenamingFolder] = useState(false);
+  const [folderTitleDraft, setFolderTitleDraft] = useState(activeFolder.title);
   const [initialRects, setInitialRects] = useState<Record<string, DOMRect>>({});
   const dragSourceRef = useRef<DragSource | null>(null);
   const folderGridRef = useRef<HTMLDivElement | null>(null);
@@ -46,6 +49,20 @@ export function FolderPanel({
   // fire onStartOutgoingDrag / onClose more than once per gesture.
   const outgoingDragStartedRef = useRef(false);
   const activePageId = tabState.pages[activeShortcutPageIndex]?.id ?? "page-1";
+
+  useEffect(() => {
+    if (!isRenamingFolder) {
+      setFolderTitleDraft(activeFolder.title);
+    }
+  }, [activeFolder.title, isRenamingFolder]);
+
+  function saveFolderTitle() {
+    const nextTitle = folderTitleDraft.trim();
+    if (nextTitle && nextTitle !== activeFolder.title) {
+      onRenameFolder(activeFolder.id, nextTitle);
+    }
+    setIsRenamingFolder(false);
+  }
 
   const clearMoveTimer = useCallback(() => {
     if (moveTimerRef.current) {
@@ -417,15 +434,38 @@ export function FolderPanel({
       >
         <div className="folder-header">
           <div>
-            <h1 id="folder-panel-title">{activeFolder.title}</h1>
+            {isRenamingFolder ? (
+              <input
+                aria-label="Folder name"
+                autoFocus
+                className="folder-title-input"
+                id="folder-panel-title"
+                onBlur={saveFolderTitle}
+                onChange={(event) => setFolderTitleDraft(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    saveFolderTitle();
+                  }
+                  if (event.key === "Escape") {
+                    setFolderTitleDraft(activeFolder.title);
+                    setIsRenamingFolder(false);
+                  }
+                }}
+                value={folderTitleDraft}
+              />
+            ) : (
+              <h1
+                id="folder-panel-title"
+                onDoubleClick={() => setIsRenamingFolder(true)}
+                title="Double-click to rename"
+              >
+                {activeFolder.title}
+              </h1>
+            )}
             <span>{activeFolder.shortcuts.length} shortcuts</span>
           </div>
           <div className="folder-actions">
-            <button className="secondary-button" type="button" onClick={() => onEditFolder(activeFolder)}>
-              Edit
-            </button>
             <button className="modal-close" type="button" onClick={onClose} aria-label="Close">
-              <span>Close</span>
               <span aria-hidden="true">×</span>
             </button>
           </div>
@@ -493,7 +533,7 @@ export function FolderPanel({
                   onEditShortcut(shortcut);
                 }}
               >
-                Edit shortcut
+                <Pencil aria-hidden="true" />
               </button>
             </div>
           );

--- a/src/ui/widgets/shortcut-grid/ShortcutGrid.tsx
+++ b/src/ui/widgets/shortcut-grid/ShortcutGrid.tsx
@@ -1,9 +1,10 @@
 import { useMemo } from "react";
 import { createPortal } from "react-dom";
 import { useReducedMotion } from "motion/react";
+import { Pencil } from "lucide-react";
 import { brandIcons } from "../../../domain/brandIcons";
 import type { DropAction } from "../../../domain/dropActions";
-import type { ResolvedFolder, ResolvedTopLevelTile } from "../../../domain/tabOperations";
+import type { ResolvedTopLevelTile } from "../../../domain/tabOperations";
 import type { Shortcut, TabState } from "../../../domain/tabState";
 import { openShortcutUrl } from "../../../infrastructure/openShortcutUrl";
 import type { DragSource } from "../../drag/dragModel";
@@ -18,7 +19,6 @@ type ShortcutGridProps = {
   gridRef: React.RefObject<HTMLElement | null>;
   outgoingDragSource: DragSource | null;
   onClearOutgoingDrag: () => void;
-  onEditFolder: (folder: ResolvedFolder) => void;
   onEditShortcut: (shortcut: Shortcut) => void;
   onSetActiveFolderId: (folderId: string | null) => void;
   onSetActiveShortcutPage: (pageIndex: number | ((current: number) => number)) => void;
@@ -37,7 +37,6 @@ export function ShortcutGrid({
   gridRef,
   outgoingDragSource,
   onClearOutgoingDrag,
-  onEditFolder,
   onEditShortcut,
   onSetActiveFolderId,
   onSetActiveShortcutPage,
@@ -157,7 +156,7 @@ export function ShortcutGrid({
                     onEditShortcut(tile.shortcut);
                   }}
                 >
-                  Edit shortcut
+                  <Pencil aria-hidden="true" />
                 </button>
               </div>
             );
@@ -189,17 +188,6 @@ export function ShortcutGrid({
               }}
             >
               <TileContent tile={tile} showLabels={showLabels} />
-              <button
-                className="quick-link-edit"
-                type="button"
-                aria-label={`Edit ${tile.folder.title}`}
-                onClick={(event: React.MouseEvent) => {
-                  event.stopPropagation();
-                  onEditFolder(tile.folder);
-                }}
-                >
-                  Edit folder
-                </button>
             </div>
           );
         })}

--- a/src/ui/widgets/shortcut-grid/ShortcutGridWidget.tsx
+++ b/src/ui/widgets/shortcut-grid/ShortcutGridWidget.tsx
@@ -1,6 +1,6 @@
 import { CSSProperties, WheelEvent, useEffect, useMemo, useRef, type RefObject } from "react";
 import type { DropAction } from "../../../domain/dropActions";
-import type { ResolvedFolder, ResolvedTopLevelTile } from "../../../domain/tabOperations";
+import type { ResolvedTopLevelTile } from "../../../domain/tabOperations";
 import type { Shortcut, TabState } from "../../../domain/tabState";
 import type { DragSource } from "../../drag/dragModel";
 import { deriveShortcutGridWidgetModel } from "./shortcutPageModel";
@@ -20,7 +20,6 @@ type ShortcutGridWidgetProps = {
   hasOverlayOpen: boolean;
   isCanvasEditMode: boolean;
   onClearOutgoingDrag: () => void;
-  onEditFolder: (folder: ResolvedFolder) => void;
   onEditShortcut: (shortcut: Shortcut) => void;
   onSetActiveFolderId: (folderId: string | null) => void;
   outgoingDragSource: DragSource | null;
@@ -40,7 +39,6 @@ export function ShortcutGridWidget({
   hasOverlayOpen,
   isCanvasEditMode,
   onClearOutgoingDrag,
-  onEditFolder,
   onEditShortcut,
   onSetActiveFolderId,
   outgoingDragSource,
@@ -67,8 +65,7 @@ export function ShortcutGridWidget({
   const { maxFittedIconSize, fittedLabelSize, fittedTileGap } = useShortcutGridMetrics(
     gridRef,
     gridLayout,
-    settings.showLabels,
-    activeShortcutPageIndex
+    settings.showLabels
   );
   const iconSize = `${Math.max(18, Math.min(maxFittedIconSize, (86 * gridLayout.iconSize) / 100))}px`;
   const labelFontSize = `${fittedLabelSize}px`;
@@ -143,7 +140,6 @@ export function ShortcutGridWidget({
         gridRef={gridRef}
         outgoingDragSource={isCanvasEditMode ? null : outgoingDragSource}
         onClearOutgoingDrag={onClearOutgoingDrag}
-        onEditFolder={onEditFolder}
         onEditShortcut={onEditShortcut}
         onSetActiveFolderId={onSetActiveFolderId}
         onSetActiveShortcutPage={setActiveShortcutPage}

--- a/src/ui/widgets/shortcut-grid/ShortcutGridWidget.tsx
+++ b/src/ui/widgets/shortcut-grid/ShortcutGridWidget.tsx
@@ -73,6 +73,7 @@ export function ShortcutGridWidget({
   const iconSize = `${Math.max(18, Math.min(maxFittedIconSize, (86 * gridLayout.iconSize) / 100))}px`;
   const labelFontSize = `${fittedLabelSize}px`;
   const tileGap = `${fittedTileGap}px`;
+  const footerHeight = settings.showPageDots && pageCount > 1 ? 56 : 18;
   const layoutStyle = {
     "--icon-size": iconSize,
     "--grid-column-gap": `${(34 * gridLayout.columnSpacing) / 100}px`,
@@ -82,8 +83,9 @@ export function ShortcutGridWidget({
     "--quick-link-label-font-size": labelFontSize,
     "--quick-link-tile-gap": tileGap,
     ...getWidgetSurfaceStyle(settings),
-    "--widget-padding": "18px 18px 8px",
-    "--widget-radius": "28px"
+    "--widget-padding": settings.showPageDots && pageCount > 1 ? "18px 18px 8px" : "18px 18px 0",
+    "--widget-radius": "28px",
+    "--shortcut-footer-height": `${footerHeight}px`
   } as CSSProperties;
   const dragOverlayStyle = {
     "--icon-size": iconSize,
@@ -129,7 +131,11 @@ export function ShortcutGridWidget({
   }
 
   return (
-    <div className="shortcut-grid-widget widget-surface" onWheel={handleShortcutWheel} style={layoutStyle}>
+    <div
+      className={`shortcut-grid-widget widget-surface${settings.showPageDots && pageCount > 1 ? "" : " no-page-dots"}`}
+      onWheel={handleShortcutWheel}
+      style={layoutStyle}
+    >
       <ShortcutGrid
         activeShortcutPageIndex={activeShortcutPageIndex}
         dragOverlayStyle={dragOverlayStyle}

--- a/src/ui/widgets/shortcut-grid/folder-panel.css
+++ b/src/ui/widgets/shortcut-grid/folder-panel.css
@@ -5,7 +5,7 @@
   display: grid;
   place-items: center;
   padding: 24px;
-  background: var(--theme-folder-backdrop-bg, rgba(7, 12, 13, 0.68));
+  background: var(--theme-folder-backdrop-bg, rgba(2, 6, 23, 0.76));
 }
 
 .folder-backdrop.folder-drop-target {
@@ -40,10 +40,10 @@
   max-height: min(640px, calc(100vh - 48px));
   grid-template-rows: auto 1fr;
   border-radius: 8px;
-  background: var(--theme-folder-panel-bg, rgba(255, 255, 255, 0.78));
+  background: color-mix(in srgb, var(--theme-folder-panel-bg, rgba(15, 23, 42, 0.82)) 34%, rgba(2, 6, 23, 0.86));
   box-shadow: 0 24px 80px rgba(0, 0, 0, 0.42);
   overflow: hidden;
-  backdrop-filter: blur(6px);
+  backdrop-filter: blur(18px) saturate(1.2);
 }
 
 .folder-header {

--- a/src/ui/widgets/shortcut-grid/folder-panel.css
+++ b/src/ui/widgets/shortcut-grid/folder-panel.css
@@ -5,7 +5,8 @@
   display: grid;
   place-items: center;
   padding: 24px;
-  background: var(--theme-folder-backdrop-bg, rgba(2, 6, 23, 0.76));
+  background: rgba(0, 0, 0, 0.68);
+  backdrop-filter: none;
 }
 
 .folder-backdrop.folder-drop-target {
@@ -39,11 +40,14 @@
   width: min(840px, 100%);
   max-height: min(640px, calc(100vh - 48px));
   grid-template-rows: auto 1fr;
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--theme-folder-panel-bg, rgba(15, 23, 42, 0.82)) 34%, rgba(2, 6, 23, 0.86));
-  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.42);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 22px;
+  background: rgba(226, 226, 222, 0.68);
+  box-shadow:
+    0 24px 80px rgba(0, 0, 0, 0.22),
+    inset 0 1px 0 rgba(255, 255, 255, 0.28);
   overflow: hidden;
-  backdrop-filter: blur(18px) saturate(1.2);
+  backdrop-filter: blur(2px);
 }
 
 .folder-header {
@@ -61,6 +65,30 @@
   font-weight: 750;
 }
 
+.folder-header h1 {
+  cursor: text;
+}
+
+.folder-title-input {
+  width: min(360px, 100%);
+  height: 40px;
+  border: 1px solid rgba(15, 23, 42, 0.16);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.68);
+  color: var(--theme-folder-panel-text, #1f2937);
+  font-size: 26px;
+  font-weight: 750;
+  line-height: 1;
+  margin: 0 0 4px;
+  outline: none;
+  padding: 0 10px;
+}
+
+.folder-title-input:focus {
+  border-color: color-mix(in srgb, var(--theme-accent, #0ea5e9) 62%, rgba(15, 23, 42, 0.16));
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--theme-accent, #0ea5e9) 18%, transparent);
+}
+
 .folder-header span {
   color: var(--theme-folder-panel-muted-text, #6b7280);
   font-size: 14px;
@@ -70,6 +98,41 @@
   display: flex;
   align-items: center;
   gap: 8px;
+}
+
+.folder-actions .modal-close {
+  display: grid;
+  width: 40px;
+  height: 40px;
+  min-width: 40px;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 50%;
+  background: rgba(15, 23, 42, 0.9);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.28);
+  color: #ffffff;
+  cursor: pointer;
+  font-size: 24px;
+  line-height: 1;
+  padding: 0;
+}
+
+.folder-actions .modal-close span[aria-hidden="true"] {
+  display: block;
+  width: auto;
+  height: auto;
+  place-items: normal;
+  border-radius: 0;
+  background: transparent !important;
+  color: inherit;
+  font-size: inherit;
+  font-weight: 500;
+  line-height: 1;
+}
+
+.folder-actions .modal-close:hover {
+  background: rgba(2, 6, 23, 0.96);
+  color: #ffffff;
 }
 
 .folder-grid {
@@ -85,6 +148,17 @@
 .folder-grid .quick-link-title {
   color: var(--theme-folder-panel-text, rgba(31, 41, 55, 0.92));
   text-shadow: none;
+}
+
+.folder-grid .quick-link-edit {
+  opacity: 0;
+  transform: translateY(4px);
+}
+
+.folder-grid .quick-link:hover .quick-link-edit,
+.folder-grid .quick-link:focus-within .quick-link-edit {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 @media (max-width: 760px) {

--- a/src/ui/widgets/shortcut-grid/shortcut-grid-widget.css
+++ b/src/ui/widgets/shortcut-grid/shortcut-grid-widget.css
@@ -12,7 +12,7 @@
   justify-items: center;
   margin-top: 0;
   padding-top: clamp(58px, 9vh, 86px);
-  animation: shortcut-page-enter 180ms ease-out;
+  animation: shortcut-page-fade 220ms ease-out;
 }
 
 .shortcut-grid-widget {
@@ -85,15 +85,13 @@
   background: var(--theme-tile-label-text, rgba(255, 255, 255, 0.96));
 }
 
-@keyframes shortcut-page-enter {
+@keyframes shortcut-page-fade {
   from {
     opacity: 0;
-    transform: translateY(10px);
   }
 
   to {
     opacity: 1;
-    transform: translateY(0);
   }
 }
 

--- a/src/ui/widgets/shortcut-grid/shortcut-grid-widget.css
+++ b/src/ui/widgets/shortcut-grid/shortcut-grid-widget.css
@@ -22,13 +22,17 @@
 
 .shortcut-grid-widget .quick-link-grid {
   width: 100%;
-  height: calc(100% - 56px);
+  height: calc(100% - var(--shortcut-footer-height, 56px));
   max-height: none;
   padding-top: 18px;
 }
 
 .shortcut-grid-widget .shortcut-page-footer {
-  min-height: 56px;
+  min-height: var(--shortcut-footer-height, 56px);
+}
+
+.shortcut-grid-widget.no-page-dots .shortcut-page-footer {
+  align-items: start;
 }
 
 .shortcut-page-footer {

--- a/src/ui/widgets/shortcut-grid/shortcutPageModel.ts
+++ b/src/ui/widgets/shortcut-grid/shortcutPageModel.ts
@@ -47,12 +47,13 @@ function deriveShortcutGridLayoutFromWidget({
   const shortcutWidgetWidth = widgetPlacement.width * canvasMetrics.cellWidth;
   const shortcutWidgetHeight = widgetPlacement.height * canvasMetrics.cellHeight;
   const shortcutIconScale = settings.iconSize / 100;
+  const footerHeight = settings.showPageDots ? 56 : 18;
   const estimatedTileWidth = Math.max(84, 86 * shortcutIconScale + 30);
   const estimatedTileHeight = Math.max(84, 86 * shortcutIconScale + (settings.showLabels ? 42 : 18));
 
   return {
     ...tabState.layout.gridLayout,
-    rows: Math.max(1, Math.floor((shortcutWidgetHeight - 56) / estimatedTileHeight)),
+    rows: Math.max(1, Math.floor((shortcutWidgetHeight - footerHeight) / estimatedTileHeight)),
     columns: Math.max(1, Math.floor(shortcutWidgetWidth / estimatedTileWidth)),
     iconSize: settings.iconSize,
     columnSpacing: settings.columnSpacing,

--- a/src/ui/widgets/shortcut-grid/shortcuts/shortcut-tiles.css
+++ b/src/ui/widgets/shortcut-grid/shortcuts/shortcut-tiles.css
@@ -150,25 +150,32 @@
 
 .quick-link-edit {
   position: absolute;
-  top: -8px;
-  right: calc(50% - var(--icon-size) / 2 - 8px);
+  top: -9px;
+  right: calc(50% - var(--icon-size) / 2 - 10px);
+  display: grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
   border: 0;
-  border-radius: 999px;
-  background: var(--theme-tile-edit-bg, rgba(255, 255, 255, 0.96));
+  border-radius: 50%;
+  background: var(--theme-tile-edit-bg, rgba(255, 255, 255, 0.94));
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.22);
   color: var(--theme-tile-edit-text, #1f2937);
   cursor: pointer;
-  font-size: 11px;
-  font-weight: 800;
-  letter-spacing: 0.01em;
-  line-height: 1;
   opacity: 0;
-  padding: 7px 10px;
+  padding: 0;
   pointer-events: auto;
   transform: translateY(4px);
   transition:
     opacity 150ms ease,
     transform 150ms ease;
   z-index: 2;
+}
+
+.quick-link-edit svg {
+  width: 15px;
+  height: 15px;
+  stroke-width: 2.6;
 }
 
 .quick-link:hover .quick-link-edit,

--- a/src/ui/widgets/shortcut-grid/useShortcutGridMetrics.ts
+++ b/src/ui/widgets/shortcut-grid/useShortcutGridMetrics.ts
@@ -16,8 +16,7 @@ const defaultMetrics: ShortcutGridMetrics = {
 export function useShortcutGridMetrics(
   gridRef: RefObject<HTMLElement | null>,
   gridLayout: GridLayoutSettings,
-  showLabels: boolean,
-  activeShortcutPageIndex: number
+  showLabels: boolean
 ): ShortcutGridMetrics {
   const [metrics, setMetrics] = useState(defaultMetrics);
 
@@ -70,7 +69,6 @@ export function useShortcutGridMetrics(
       window.removeEventListener("resize", measure);
     };
   }, [
-    activeShortcutPageIndex,
     gridLayout.columns,
     gridLayout.columnSpacing,
     gridLayout.lineSpacing,

--- a/src/ui/widgets/weather/WeatherWidget.tsx
+++ b/src/ui/widgets/weather/WeatherWidget.tsx
@@ -48,14 +48,7 @@ export function WeatherWidget({ settings }: WeatherWidgetProps) {
       });
 
     return () => controller.abort();
-  }, [
-    settings.latitude,
-    settings.longitude,
-    settings.units,
-    settings.locationName,
-    settings.refreshMinutes,
-    settings.displayMode
-  ]);
+  }, [settings.latitude, settings.longitude, settings.units, settings.locationName, settings.refreshMinutes]);
 
   if (status.type === "loading") {
     return (

--- a/src/ui/widgets/weather/WeatherWidgetContextMenu.tsx
+++ b/src/ui/widgets/weather/WeatherWidgetContextMenu.tsx
@@ -5,12 +5,14 @@ import { resolveWeatherLocation } from "./weatherService";
 
 type WeatherWidgetContextMenuProps = {
   changeWeatherWidgetSetting: <K extends keyof WeatherWidgetSettings>(key: K, value: WeatherWidgetSettings[K]) => void;
+  changeWeatherWidgetSettings: (settings: Partial<WeatherWidgetSettings>) => void;
   setEnabled: (enabled: boolean) => void;
   weatherWidget: WidgetState<WeatherWidgetSettings>;
 };
 
 export function WeatherWidgetContextMenu({
   changeWeatherWidgetSetting,
+  changeWeatherWidgetSettings,
   setEnabled,
   weatherWidget
 }: WeatherWidgetContextMenuProps) {
@@ -27,9 +29,11 @@ export function WeatherWidgetContextMenu({
 
     try {
       const result = await resolveWeatherLocation(locationDraft);
-      changeWeatherWidgetSetting("locationName", result.name);
-      changeWeatherWidgetSetting("latitude", result.latitude);
-      changeWeatherWidgetSetting("longitude", result.longitude);
+      changeWeatherWidgetSettings({
+        locationName: result.name,
+        latitude: result.latitude,
+        longitude: result.longitude
+      });
       setLocationDraft(result.name);
       setLocationStatus("Location updated");
     } catch (error) {

--- a/src/ui/widgets/weather/weather-widget.css
+++ b/src/ui/widgets/weather/weather-widget.css
@@ -1,10 +1,11 @@
 .weather-widget {
+  container-type: size;
   display: grid;
   width: 100%;
   height: 100%;
   min-height: 0;
   align-content: center;
-  gap: 10px;
+  gap: clamp(8px, 4cqh, 16px);
   color: var(--theme-text, #f8fafc);
 }
 
@@ -12,16 +13,16 @@
   display: flex;
   min-width: 0;
   align-items: center;
-  gap: 12px;
+  gap: clamp(10px, 4cqw, 18px);
 }
 
 .weather-icon {
   display: grid;
-  width: clamp(42px, 28%, 68px);
+  width: clamp(42px, min(22cqw, 36cqh), 96px);
   aspect-ratio: 1;
   flex: 0 0 auto;
   place-items: center;
-  border-radius: 22px;
+  border-radius: clamp(18px, 7cqw, 30px);
   background: rgba(255, 255, 255, 0.12);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.16);
 }
@@ -46,7 +47,7 @@
 
 .weather-temp-group strong {
   color: #ffffff;
-  font-size: clamp(28px, 8vw, 46px);
+  font-size: clamp(28px, min(18cqw, 26cqh), 78px);
   font-weight: 950;
   letter-spacing: -0.07em;
   line-height: 0.95;
@@ -58,7 +59,7 @@
 .weather-detail span {
   overflow: hidden;
   color: var(--theme-muted-text, rgba(226, 232, 240, 0.78));
-  font-size: clamp(11px, 1.4vw, 13px);
+  font-size: clamp(11px, min(4cqw, 7cqh), 18px);
   font-weight: 800;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -66,7 +67,7 @@
 
 .weather-secondary {
   display: grid;
-  gap: 6px;
+  gap: clamp(5px, 2cqh, 10px);
 }
 
 .weather-secondary span,
@@ -74,13 +75,13 @@
   display: flex;
   min-width: 0;
   align-items: center;
-  gap: 6px;
+  gap: clamp(5px, 2cqw, 10px);
 }
 
 .weather-secondary svg,
 .weather-detail svg {
-  width: 14px;
-  height: 14px;
+  width: clamp(14px, min(4cqw, 7cqh), 22px);
+  height: clamp(14px, min(4cqw, 7cqh), 22px);
   flex: 0 0 auto;
   color: var(--theme-accent, #7dd3fc);
 }
@@ -88,7 +89,7 @@
 .weather-details {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 7px;
+  gap: clamp(6px, 2.4cqw, 12px);
 }
 
 .weather-detail {
@@ -96,16 +97,16 @@
   min-width: 0;
   justify-items: start;
   gap: 4px;
-  border-radius: 16px;
+  border-radius: clamp(14px, 5cqw, 22px);
   background: rgba(255, 255, 255, 0.08);
-  padding: 8px;
+  padding: clamp(7px, min(2.8cqw, 4cqh), 14px);
 }
 
 .weather-detail strong {
   overflow: hidden;
   max-width: 100%;
   color: #ffffff;
-  font-size: 12px;
+  font-size: clamp(12px, min(3.4cqw, 5cqh), 18px);
   font-weight: 950;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -113,7 +114,7 @@
 
 .weather-widget-compact {
   align-content: center;
-  gap: 5px;
+  gap: clamp(5px, 3cqh, 10px);
 }
 
 .weather-widget-compact .weather-primary {
@@ -133,22 +134,22 @@
 
 .weather-widget-loading svg,
 .weather-widget-error > svg {
-  width: 28px;
-  height: 28px;
+  width: clamp(28px, min(10cqw, 18cqh), 48px);
+  height: clamp(28px, min(10cqw, 18cqh), 48px);
   color: var(--theme-accent, #7dd3fc);
 }
 
 .weather-widget-loading span,
 .weather-widget-error span {
   color: var(--theme-muted-text, rgba(226, 232, 240, 0.8));
-  font-size: 12px;
+  font-size: clamp(12px, min(4cqw, 7cqh), 18px);
   font-weight: 800;
 }
 
 .weather-widget-error strong {
   display: block;
   color: #ffffff;
-  font-size: 13px;
+  font-size: clamp(13px, min(4.4cqw, 7cqh), 20px);
   font-weight: 950;
 }
 

--- a/src/ui/widgets/weather/weatherService.ts
+++ b/src/ui/widgets/weather/weatherService.ts
@@ -59,11 +59,21 @@ type OpenMeteoForecastResponse = {
 };
 
 const cache = new Map<string, WeatherSnapshot>();
+const locationCache = new Map<string, WeatherLocationResult>();
+const persistentWeatherCacheKey = "snapTabWeatherCache";
+const persistentLocationCacheKey = "snapTabWeatherLocationCache";
 
 export async function resolveWeatherLocation(query: string, signal?: AbortSignal): Promise<WeatherLocationResult> {
   const trimmedQuery = query.trim();
   if (!trimmedQuery) {
     throw new Error("Enter a location.");
+  }
+
+  const cacheKey = trimmedQuery.toLocaleLowerCase();
+  const cached = locationCache.get(cacheKey) ?? (await readPersistentCache<WeatherLocationResult>(persistentLocationCacheKey))[cacheKey];
+  if (cached) {
+    locationCache.set(cacheKey, cached);
+    return cached;
   }
 
   const params = new URLSearchParams({ name: trimmedQuery, count: "1", language: "en", format: "json" });
@@ -78,18 +88,31 @@ export async function resolveWeatherLocation(query: string, signal?: AbortSignal
     throw new Error("Location not found.");
   }
 
-  return {
+  const location = {
     name: [result.name, result.admin1, result.country].filter(Boolean).join(", "),
     latitude: result.latitude,
     longitude: result.longitude
   };
+
+  locationCache.set(cacheKey, location);
+  await writePersistentCache(persistentLocationCacheKey, cacheKey, location);
+  return location;
 }
 
 export async function fetchWeatherSnapshot(settings: WeatherWidgetSettings, signal?: AbortSignal): Promise<WeatherSnapshot> {
   const cacheKey = `${settings.latitude.toFixed(3)}:${settings.longitude.toFixed(3)}:${settings.units}`;
   const cached = cache.get(cacheKey);
   if (cached && Date.now() - cached.fetchedAt < settings.refreshMinutes * 60_000) {
-    return cached;
+    return withCurrentLocationName(cached, settings.locationName);
+  }
+
+  const persistentCache = await readPersistentCache<WeatherSnapshot>(persistentWeatherCacheKey);
+  const persistentSnapshot = persistentCache[cacheKey];
+  if (persistentSnapshot) {
+    cache.set(cacheKey, persistentSnapshot);
+    if (Date.now() - persistentSnapshot.fetchedAt < settings.refreshMinutes * 60_000) {
+      return withCurrentLocationName(persistentSnapshot, settings.locationName);
+    }
   }
 
   const params = new URLSearchParams({
@@ -112,14 +135,23 @@ export async function fetchWeatherSnapshot(settings: WeatherWidgetSettings, sign
     params.set("temperature_unit", "fahrenheit");
   }
 
-  const response = await fetch(`https://api.open-meteo.com/v1/forecast?${params.toString()}`, { signal });
-  if (!response.ok) {
-    throw new Error("Weather fetch failed.");
-  }
+  let data: OpenMeteoForecastResponse;
+  try {
+    const response = await fetch(`https://api.open-meteo.com/v1/forecast?${params.toString()}`, { signal });
+    if (!response.ok) {
+      throw new Error("Weather fetch failed.");
+    }
 
-  const data = (await response.json()) as OpenMeteoForecastResponse;
-  if (!data.current) {
-    throw new Error("Weather data unavailable.");
+    data = (await response.json()) as OpenMeteoForecastResponse;
+    if (!data.current) {
+      throw new Error("Weather data unavailable.");
+    }
+  } catch (error) {
+    if (persistentSnapshot && !signal?.aborted) {
+      return withCurrentLocationName(persistentSnapshot, settings.locationName);
+    }
+
+    throw error;
   }
 
   const snapshot: WeatherSnapshot = {
@@ -141,7 +173,46 @@ export async function fetchWeatherSnapshot(settings: WeatherWidgetSettings, sign
   };
 
   cache.set(cacheKey, snapshot);
+  await writePersistentCache(persistentWeatherCacheKey, cacheKey, snapshot);
   return snapshot;
+}
+
+function withCurrentLocationName(snapshot: WeatherSnapshot, locationName: string): WeatherSnapshot {
+  return snapshot.locationName === locationName ? snapshot : { ...snapshot, locationName };
+}
+
+async function readPersistentCache<T>(key: string): Promise<Record<string, T>> {
+  const chromeLocal = typeof chrome !== "undefined" ? chrome.storage?.local : undefined;
+  if (chromeLocal) {
+    return new Promise((resolve) => {
+      chromeLocal.get([key], (items) => {
+        resolve(isRecord(items[key]) ? (items[key] as Record<string, T>) : {});
+      });
+    });
+  }
+
+  try {
+    const value = window.localStorage.getItem(key);
+    const parsed = value ? (JSON.parse(value) as unknown) : null;
+    return isRecord(parsed) ? (parsed as Record<string, T>) : {};
+  } catch {
+    return {};
+  }
+}
+
+async function writePersistentCache<T>(key: string, cacheKey: string, value: T) {
+  const nextCache = { ...(await readPersistentCache<T>(key)), [cacheKey]: value };
+  const chromeLocal = typeof chrome !== "undefined" ? chrome.storage?.local : undefined;
+  if (chromeLocal) {
+    await new Promise<void>((resolve) => chromeLocal.set({ [key]: nextCache }, () => resolve()));
+    return;
+  }
+
+  window.localStorage.setItem(key, JSON.stringify(nextCache));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }
 
 export function describeWeatherCode(code: number): WeatherCondition {

--- a/src/ui/widgets/widgets.css
+++ b/src/ui/widgets/widgets.css
@@ -6,3 +6,4 @@
 @import "./shortcut-grid/shortcuts/shortcut-tiles.css";
 @import "./weather/weather-widget.css";
 @import "./date-time/date-time-widget.css";
+@import "./rss/rss-widget.css";

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -19,6 +19,11 @@ type ChromeTabs = {
   remove?: (tabId: number, callback?: () => void) => void;
 };
 
+type ChromeStorageChangeEvent = {
+  addListener: (callback: (changes: Record<string, unknown>, areaName: string) => void) => void;
+  removeListener: (callback: (changes: Record<string, unknown>, areaName: string) => void) => void;
+};
+
 declare const chrome:
   | {
       runtime?: {
@@ -28,6 +33,7 @@ declare const chrome:
       };
       storage?: {
         local?: ChromeStorageArea;
+        onChanged?: ChromeStorageChangeEvent;
       };
       tabs?: ChromeTabs;
     }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -30,6 +30,7 @@ declare const chrome:
         lastError?: {
           message?: string;
         };
+        sendMessage?: (message: unknown, callback: (response: unknown) => void) => void;
       };
       storage?: {
         local?: ChromeStorageArea;

--- a/tests/smoke/smoke.spec.ts
+++ b/tests/smoke/smoke.spec.ts
@@ -82,6 +82,24 @@ test("shortcut edit can persist a manual fallback icon", async ({ page }) => {
   await expect(docsIcon).toHaveCSS("background-color", "rgb(18, 52, 86)");
 });
 
+test("folder name can be edited by double-clicking its opened title", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "snapTabState",
+      JSON.stringify({ state: { schemaVersion: 2, pages: [{ id: "page-1", tileIds: ["work-folder"] }] }, version: 2 })
+    );
+  });
+  await page.goto("/newtab.html");
+  await page.locator('[data-tile-key="folder:work-folder"]').click();
+
+  await expect(page.getByRole("dialog")).toBeVisible();
+  await page.getByRole("heading", { name: "Work" }).dblclick();
+  await page.getByLabel("Folder name").fill("Projects");
+  await page.keyboard.press("Enter");
+
+  await expect(page.getByRole("heading", { name: "Projects" })).toBeVisible();
+});
+
 test("dev root renders the New Tab Surface", async ({ page }) => {
   const pageErrors: Error[] = [];
   page.on("pageerror", (error) => pageErrors.push(error));
@@ -282,6 +300,67 @@ test("Weather and Date & Time typography scale with widget size", async ({ page 
   expect(large.weatherFont).toBeGreaterThan(small.weatherFont + 20);
   expect(large.clockFont).toBeGreaterThan(small.clockFont + 20);
   expect(large.clockDigitHeadroom).toBeGreaterThanOrEqual(0);
+});
+
+test("Shortcut Page transitions keep icon size stable", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "snapTabState",
+      JSON.stringify({
+        state: {
+          schemaVersion: 2,
+          canvas: {
+            targetCellSize: 56,
+            widgets: {
+              shortcutGrid: {
+                enabled: true,
+                placement: { x: 9, y: 4, width: 10, height: 5, zIndex: 5 },
+                settings: {
+                  columnSpacing: 70,
+                  iconSize: 150,
+                  lineSpacing: 70,
+                  showLabels: true,
+                  showPageDots: true
+                }
+              }
+            }
+          },
+          layout: {
+            gridLayout: {
+              columnSpacing: 100,
+              columns: 6,
+              iconSize: 100,
+              lineSpacing: 100,
+              mode: "custom",
+              presetId: "2x6",
+              rows: 2
+            }
+          }
+        },
+        version: 2
+      })
+    );
+  });
+
+  await page.goto("/newtab.html");
+  await page.waitForSelector(".quick-link-icon");
+  await page.waitForTimeout(350);
+
+  const before = await page.locator(".quick-link-icon").first().boundingBox();
+  expect(before).not.toBeNull();
+
+  await page.locator(".shortcut-page-dots button").nth(1).click();
+  const widths: number[] = [];
+  for (let index = 0; index < 8; index += 1) {
+    await page.waitForTimeout(30);
+    const box = await page.locator(".quick-link-icon").first().boundingBox();
+    if (box) {
+      widths.push(box.width);
+    }
+  }
+
+  expect(widths.length).toBeGreaterThan(0);
+  expect(Math.max(...widths.map((width) => Math.abs(width - before!.width)))).toBeLessThanOrEqual(1);
 });
 
 test("settings drawer renders backup controls", async ({ page }) => {

--- a/tests/smoke/smoke.spec.ts
+++ b/tests/smoke/smoke.spec.ts
@@ -225,6 +225,65 @@ test("Search Widget edit frame wraps tabs and search bar", async ({ page }) => {
   expect(frameBox!.y + frameBox!.height).toBeGreaterThanOrEqual(searchBoxBox!.y + searchBoxBox!.height - 1);
 });
 
+test("Weather and Date & Time typography scale with widget size", async ({ page }) => {
+  await page.route("https://api.open-meteo.com/**", (route) =>
+    route.fulfill({
+      json: {
+        current: {
+          apparent_temperature: 22,
+          is_day: 1,
+          precipitation: 0,
+          relative_humidity_2m: 50,
+          temperature_2m: 21,
+          weather_code: 0,
+          wind_direction_10m: 90,
+          wind_speed_10m: 5
+        },
+        current_units: {
+          precipitation: "mm",
+          temperature_2m: "°C",
+          wind_speed_10m: "km/h"
+        }
+      }
+    })
+  );
+  await page.goto("/newtab.html");
+
+  async function measureWidgets(size: { weatherWidth: number; weatherHeight: number; clockWidth: number; clockHeight: number }) {
+    await page.evaluate((nextState) => {
+      window.localStorage.setItem("snapTabState", JSON.stringify({ state: nextState, version: 2 }));
+    }, buildResponsiveWidgetState(size));
+    await page.goto("/newtab.html");
+    await page.waitForSelector(".weather-temp-group strong");
+    await page.waitForSelector(".date-time-vertical strong");
+
+    return page.evaluate(() => {
+      const weatherTemperature = document.querySelector(".weather-temp-group strong");
+      const weatherIcon = document.querySelector(".weather-icon");
+      const clockDigit = document.querySelector(".date-time-vertical strong");
+      if (!weatherTemperature || !weatherIcon || !clockDigit) {
+        throw new Error("Responsive widgets did not render.");
+      }
+
+      return {
+        clockFont: parseFloat(window.getComputedStyle(clockDigit).fontSize),
+        clockDigitHeadroom: clockDigit.clientWidth - clockDigit.scrollWidth,
+        weatherFont: parseFloat(window.getComputedStyle(weatherTemperature).fontSize),
+        weatherIconWidth: weatherIcon.getBoundingClientRect().width
+      };
+    });
+  }
+
+  const small = await measureWidgets({ weatherWidth: 4, weatherHeight: 3, clockWidth: 4, clockHeight: 2 });
+  const large = await measureWidgets({ weatherWidth: 10, weatherHeight: 7, clockWidth: 12, clockHeight: 5 });
+
+  expect(small.weatherIconWidth).toBeGreaterThanOrEqual(40);
+  expect(large.weatherIconWidth).toBeGreaterThan(small.weatherIconWidth + 30);
+  expect(large.weatherFont).toBeGreaterThan(small.weatherFont + 20);
+  expect(large.clockFont).toBeGreaterThan(small.clockFont + 20);
+  expect(large.clockDigitHeadroom).toBeGreaterThanOrEqual(0);
+});
+
 test("settings drawer renders backup controls", async ({ page }) => {
   await page.goto("/newtab.html");
   await page.getByRole("button", { name: "Open settings menu" }).click();
@@ -250,3 +309,73 @@ test("wallpaper upload accepts a GIF and renders it", async ({ page }) => {
   await expect(page.getByText("Wallpaper saved.")).toBeVisible();
   await expect(page.locator(".wallpaper-media")).toBeVisible();
 });
+
+function buildResponsiveWidgetState(size: { weatherWidth: number; weatherHeight: number; clockWidth: number; clockHeight: number }) {
+  return {
+    schemaVersion: 2,
+    canvas: {
+      targetCellSize: 56,
+      widgets: {
+        search: {
+          enabled: false,
+          placement: { x: 0, y: 0, width: 1, height: 1, zIndex: 1 }
+        },
+        shortcutGrid: {
+          enabled: false,
+          placement: { x: 0, y: 0, width: 1, height: 1, zIndex: 1 }
+        },
+        weather: {
+          enabled: true,
+          placement: { x: 1, y: 1, width: size.weatherWidth, height: size.weatherHeight, zIndex: 5 },
+          settings: {
+            displayMode: "expanded",
+            latitude: 51.5072,
+            locationName: "London",
+            longitude: -0.1276,
+            refreshMinutes: 10,
+            showFeelsLike: true,
+            showHumidity: true,
+            showPrecipitation: true,
+            showWind: true,
+            units: "celsius"
+          }
+        },
+        dateTime: {
+          enabled: true,
+          placement: { x: 14, y: 1, width: size.clockWidth, height: size.clockHeight, zIndex: 6 },
+          settings: {
+            clockMode: "verticalClock",
+            dateMode: "long",
+            dateOrder: "DMY",
+            hourColor: "#f8fafc",
+            minuteColor: "#7dd3fc",
+            padDate: true,
+            padHour: true,
+            secondColor: "#fde68a",
+            shortSeparator: "dots",
+            showOrdinalDay: true,
+            showSeconds: true,
+            showWeekNumber: false,
+            showWeekday: true,
+            timeFormat: "twentyFourHour",
+            timezone: "auto"
+          }
+        }
+      }
+    },
+    layout: {
+      gridLayout: {
+        columnSpacing: 100,
+        columns: 6,
+        iconSize: 100,
+        lineSpacing: 100,
+        mode: "preset",
+        presetId: "2x6",
+        rows: 2
+      }
+    },
+    pages: [{ id: "page-1", tileIds: [] }],
+    tiles: {},
+    wallpaper: { type: "none", value: null, mediaId: null, dim: 40, blur: 0 }
+  };
+}

--- a/tests/unit/domain/canvas.test.ts
+++ b/tests/unit/domain/canvas.test.ts
@@ -22,14 +22,16 @@ describe("canvas placement", () => {
       search: { x: 11.5, y: 2, width: 11, height: 1, zIndex: 10 },
       shortcutGrid: { x: 10.5, y: 5, width: 13, height: 7, zIndex: 5 },
       weather: { x: 0, y: 15, width: 7, height: 4, zIndex: 8 },
-      dateTime: { x: 0, y: 0, width: 7, height: 3, zIndex: 8 }
+      dateTime: { x: 0, y: 0, width: 7, height: 3, zIndex: 8 },
+      rss: { x: 26, y: 0, width: 8, height: 5, zIndex: 8 }
     });
 
     expect(deriveDefaultWidgetPlacements({ columns: 20, rows: 12 })).toEqual({
       search: { x: 4.5, y: 2, width: 11, height: 1, zIndex: 10 },
       shortcutGrid: { x: 3.5, y: 5, width: 13, height: 6, zIndex: 5 },
       weather: { x: 0, y: 8, width: 7, height: 4, zIndex: 8 },
-      dateTime: { x: 0, y: 0, width: 7, height: 3, zIndex: 8 }
+      dateTime: { x: 0, y: 0, width: 7, height: 3, zIndex: 8 },
+      rss: { x: 12, y: 0, width: 8, height: 5, zIndex: 8 }
     });
   });
 
@@ -46,6 +48,9 @@ describe("canvas placement", () => {
     expect(
       resolveResponsiveDefaultWidgetPlacement("dateTime", { x: 0, y: 0, width: 7, height: 3, zIndex: 8 }, { columns: 20, rows: 12 })
     ).toEqual({ x: 0, y: 0, width: 7, height: 3, zIndex: 8 });
+    expect(
+      resolveResponsiveDefaultWidgetPlacement("rss", { x: 26, y: 0, width: 8, height: 5, zIndex: 8 }, { columns: 20, rows: 12 })
+    ).toEqual({ x: 12, y: 0, width: 8, height: 5, zIndex: 8 });
   });
 
   it("keeps fractional placement while clamping inside the canvas", () => {

--- a/tests/unit/domain/canvas.test.ts
+++ b/tests/unit/domain/canvas.test.ts
@@ -21,14 +21,14 @@ describe("canvas placement", () => {
     expect(deriveDefaultWidgetPlacements({ columns: 34, rows: 19 })).toEqual({
       search: { x: 11.5, y: 2, width: 11, height: 1, zIndex: 10 },
       shortcutGrid: { x: 10.5, y: 5, width: 13, height: 7, zIndex: 5 },
-      weather: { x: 0, y: 16, width: 5, height: 3, zIndex: 8 },
+      weather: { x: 0, y: 15, width: 7, height: 4, zIndex: 8 },
       dateTime: { x: 0, y: 0, width: 7, height: 3, zIndex: 8 }
     });
 
     expect(deriveDefaultWidgetPlacements({ columns: 20, rows: 12 })).toEqual({
       search: { x: 4.5, y: 2, width: 11, height: 1, zIndex: 10 },
       shortcutGrid: { x: 3.5, y: 5, width: 13, height: 6, zIndex: 5 },
-      weather: { x: 0, y: 9, width: 5, height: 3, zIndex: 8 },
+      weather: { x: 0, y: 8, width: 7, height: 4, zIndex: 8 },
       dateTime: { x: 0, y: 0, width: 7, height: 3, zIndex: 8 }
     });
   });
@@ -42,7 +42,7 @@ describe("canvas placement", () => {
     expect(resolveResponsiveDefaultWidgetPlacement("search", customPlacement, { columns: 20, rows: 12 })).toBe(customPlacement);
     expect(
       resolveResponsiveDefaultWidgetPlacement("weather", { x: 29, y: 0, width: 5, height: 2, zIndex: 8 }, { columns: 20, rows: 12 })
-    ).toEqual({ x: 0, y: 9, width: 5, height: 3, zIndex: 8 });
+    ).toEqual({ x: 0, y: 8, width: 7, height: 4, zIndex: 8 });
     expect(
       resolveResponsiveDefaultWidgetPlacement("dateTime", { x: 0, y: 0, width: 7, height: 3, zIndex: 8 }, { columns: 20, rows: 12 })
     ).toEqual({ x: 0, y: 0, width: 7, height: 3, zIndex: 8 });

--- a/tests/unit/domain/rss.test.ts
+++ b/tests/unit/domain/rss.test.ts
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { parseOpmlFeeds, parseRssXml, serializeOpmlFeeds } from "../../../src/domain/rss";
+import type { RssFeed } from "../../../src/domain/canvas";
+
+describe("OPML feeds", () => {
+  it("parses RSS outlines and skips duplicate feed URLs", () => {
+    const feeds = parseOpmlFeeds(`
+      <opml version="2.0">
+        <body>
+          <outline text="Tech">
+            <outline type="rss" title="Example News" xmlUrl="https://example.com/feed.xml" />
+            <outline type="rss" text="Duplicate" xmlUrl="https://example.com/feed.xml#latest" />
+            <outline text="No URL" />
+          </outline>
+          <outline type="rss" text="Atom Feed" xmlUrl="https://example.com/atom.xml" />
+        </body>
+      </opml>
+    `);
+
+    expect(feeds).toEqual([
+      expect.objectContaining({ title: "Example News", url: "https://example.com/feed.xml" }),
+      expect.objectContaining({ title: "Atom Feed", url: "https://example.com/atom.xml" })
+    ]);
+  });
+
+  it("serializes feeds as importable OPML", () => {
+    const feeds: RssFeed[] = [{ id: "rss-one", title: "A & B", url: "https://example.com/feed.xml" }];
+    const opml = serializeOpmlFeeds(feeds);
+
+    expect(opml).toContain('<opml version="2.0">');
+    expect(opml).toContain('title="A &amp; B"');
+    expect(parseOpmlFeeds(opml)).toEqual([expect.objectContaining({ title: "A & B", url: "https://example.com/feed.xml" })]);
+  });
+
+  it("parses Smart Launcher OPML 1.0 exports with nested text outlines", () => {
+    const feeds = parseOpmlFeeds(`
+      <?xml version="1.0" encoding="UTF-8"?>
+      <opml version="1.0">
+        <head><title>Your Feed List</title></head>
+        <body>
+          <outline text="RSS Feeds">
+            <outline text="Android Developers Blog" type="rss" xmlUrl="https://feeds.feedburner.com/blogspot/hsDu"/>
+            <outline text="Baeldung" type="rss" xmlUrl="https://feeds.feedblitz.com/baeldung&x=1"/>
+            <outline text="It's FOSS" type="rss" xmlUrl="https://itsfoss.com/rss/"/>
+          </outline>
+        </body>
+      </opml>
+    `);
+
+    expect(feeds).toEqual([
+      expect.objectContaining({ title: "Android Developers Blog", url: "https://feeds.feedburner.com/blogspot/hsDu" }),
+      expect.objectContaining({ title: "Baeldung", url: "https://feeds.feedblitz.com/baeldung&x=1" }),
+      expect.objectContaining({ title: "It's FOSS", url: "https://itsfoss.com/rss/" })
+    ]);
+  });
+});
+
+describe("RSS XML parsing", () => {
+  const feed: RssFeed = { id: "rss-example", title: "Example", url: "https://example.com/feed.xml" };
+
+  it("parses RSS 2.0 items", () => {
+    const parsed = parseRssXml(
+      `
+        <rss version="2.0">
+          <channel>
+            <title>Example News</title>
+            <item>
+              <title>First story</title>
+              <link>https://example.com/first</link>
+              <description><![CDATA[<p>First summary</p>]]></description>
+              <pubDate>Mon, 01 Jan 2024 10:00:00 GMT</pubDate>
+              <author>editor@example.com</author>
+              <guid>first-guid</guid>
+            </item>
+          </channel>
+        </rss>
+      `,
+      feed
+    );
+
+    expect(parsed.title).toBe("Example News");
+    expect(parsed.items[0]).toEqual(
+      expect.objectContaining({
+        feedId: "rss-example",
+        feedTitle: "Example News",
+        title: "First story",
+        link: "https://example.com/first",
+        snippet: "First summary",
+        publishedAt: "2024-01-01T10:00:00.000Z",
+        author: "editor@example.com"
+      })
+    );
+  });
+
+  it("extracts RSS item images from media, enclosure, and description HTML", () => {
+    const parsed = parseRssXml(
+      `
+        <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+          <channel>
+            <title>Image Feed</title>
+            <item>
+              <title>Media thumbnail story</title>
+              <link>https://example.com/media</link>
+              <media:thumbnail url="https://cdn.example.com/thumb.jpg" />
+            </item>
+            <item>
+              <title>Enclosure story</title>
+              <link>https://example.com/enclosure</link>
+              <enclosure url="https://cdn.example.com/enclosure.jpg" type="image/jpeg" />
+            </item>
+            <item>
+              <title>Description story</title>
+              <link>https://example.com/posts/description</link>
+              <description><![CDATA[<p>Story</p><img src="/images/description.jpg" />]]></description>
+            </item>
+          </channel>
+        </rss>
+      `,
+      feed
+    );
+
+    expect(parsed.items.map((item) => item.imageUrl)).toEqual([
+      "https://cdn.example.com/thumb.jpg",
+      "https://cdn.example.com/enclosure.jpg",
+      "https://example.com/images/description.jpg"
+    ]);
+  });
+
+  it("parses Atom entries", () => {
+    const parsed = parseRssXml(
+      `
+        <feed xmlns="http://www.w3.org/2005/Atom">
+          <title>Example Atom</title>
+          <entry>
+            <id>tag:example.com,2024:second</id>
+            <title>Second story</title>
+            <link href="https://example.com/second" />
+            <summary>Second summary</summary>
+            <updated>2024-02-02T09:30:00Z</updated>
+            <author><name>Ada</name></author>
+          </entry>
+        </feed>
+      `,
+      feed
+    );
+
+    expect(parsed.title).toBe("Example Atom");
+    expect(parsed.items[0]).toEqual(
+      expect.objectContaining({
+        title: "Second story",
+        link: "https://example.com/second",
+        snippet: "Second summary",
+        publishedAt: "2024-02-02T09:30:00.000Z",
+        author: "Ada"
+      })
+    );
+  });
+
+  it("extracts Atom item images from content HTML", () => {
+    const parsed = parseRssXml(
+      `
+        <feed xmlns="http://www.w3.org/2005/Atom">
+          <title>Example Atom</title>
+          <entry>
+            <id>tag:example.com,2024:image</id>
+            <title>Image story</title>
+            <link href="https://example.com/posts/image" />
+            <content type="html"><![CDATA[<p>Story</p><img src="https://cdn.example.com/atom.jpg" />]]></content>
+          </entry>
+        </feed>
+      `,
+      feed
+    );
+
+    expect(parsed.items[0].imageUrl).toBe("https://cdn.example.com/atom.jpg");
+  });
+});

--- a/tests/unit/domain/tabState.test.ts
+++ b/tests/unit/domain/tabState.test.ts
@@ -247,6 +247,21 @@ describe("normalizeTabState", () => {
     expect(normalized.canvas.widgets.dateTime.settings.dateMode).toBe("long");
   });
 
+  it("backfills RSS Widget defaults for persisted Canvas state without rss", () => {
+    const { rss: _rss, ...widgetsWithoutRss } = defaultTabState.canvas.widgets;
+    const normalized = normalizeTabState({
+      ...defaultTabState,
+      canvas: {
+        ...defaultTabState.canvas,
+        widgets: widgetsWithoutRss
+      }
+    });
+
+    expect(normalized.canvas.widgets.rss.enabled).toBe(true);
+    expect(normalized.canvas.widgets.rss.settings.feedMode).toBe("all");
+    expect(normalized.canvas.widgets.rss.settings.feeds).toEqual([]);
+  });
+
   it("normalizes invalid Weather Widget settings", () => {
     const normalized = normalizeTabState({
       ...defaultTabState,
@@ -309,6 +324,45 @@ describe("normalizeTabState", () => {
     expect(normalized.canvas.widgets.dateTime.settings.shortSeparator).toBe("dots");
     expect(normalized.canvas.widgets.dateTime.settings.timezone).toBe("auto");
     expect(normalized.canvas.widgets.dateTime.settings.hourColor).toBe("#f8fafc");
+  });
+
+  it("normalizes invalid RSS Widget settings", () => {
+    const normalized = normalizeTabState({
+      ...defaultTabState,
+      canvas: {
+        ...defaultTabState.canvas,
+        widgets: {
+          ...defaultTabState.canvas.widgets,
+          rss: {
+            ...defaultTabState.canvas.widgets.rss,
+            settings: {
+              ...defaultTabState.canvas.widgets.rss.settings,
+              feeds: [
+                { id: "feed-one", title: "Example", url: "https://example.com/feed.xml" },
+                { id: "feed-two", title: "Duplicate", url: "https://example.com/feed.xml#duplicate" },
+                { id: "bad", title: "Bad", url: "ftp://example.com/feed.xml" }
+              ],
+              feedMode: "solo",
+              selectedFeedId: "missing",
+              displayMode: "huge",
+              maxItems: 200,
+              maxItemsPerFeed: 0,
+              refreshMinutes: 1
+            }
+          }
+        }
+      }
+    });
+
+    expect(normalized.canvas.widgets.rss.settings.feeds).toEqual([
+      { id: "feed-one", title: "Example", url: "https://example.com/feed.xml" }
+    ]);
+    expect(normalized.canvas.widgets.rss.settings.feedMode).toBe("all");
+    expect(normalized.canvas.widgets.rss.settings.selectedFeedId).toBeNull();
+    expect(normalized.canvas.widgets.rss.settings.displayMode).toBe("standard");
+    expect(normalized.canvas.widgets.rss.settings.maxItems).toBe(20);
+    expect(normalized.canvas.widgets.rss.settings.maxItemsPerFeed).toBe(1);
+    expect(normalized.canvas.widgets.rss.settings.refreshMinutes).toBe(5);
   });
 });
 

--- a/tests/unit/ui/widgets/DateTimeWidgetContextMenu.test.tsx
+++ b/tests/unit/ui/widgets/DateTimeWidgetContextMenu.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { defaultCanvasState } from "../../../../src/domain/canvas";
+import { DateTimeWidgetContextMenu } from "../../../../src/ui/widgets/date-time/DateTimeWidgetContextMenu";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("DateTimeWidgetContextMenu", () => {
+  let root: ReturnType<typeof createRoot> | undefined;
+  let container: HTMLDivElement | undefined;
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount());
+    }
+    container?.remove();
+    root = undefined;
+    container = undefined;
+  });
+
+  it("routes hour, minute, and second choices through one shared color picker", () => {
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+
+    const changeDateTimeWidgetSetting = vi.fn();
+    const settings = defaultCanvasState.widgets.dateTime.settings;
+
+    act(() => {
+      root?.render(
+        <DateTimeWidgetContextMenu
+          changeDateTimeWidgetSetting={changeDateTimeWidgetSetting}
+          dateTimeWidget={defaultCanvasState.widgets.dateTime}
+          setEnabled={vi.fn()}
+        />
+      );
+    });
+
+    const colorInputs = container.querySelectorAll<HTMLInputElement>('input[type="color"]');
+    expect(colorInputs).toHaveLength(1);
+
+    const colorInput = colorInputs[0];
+    const click = vi.spyOn(colorInput, "click").mockImplementation(() => undefined);
+
+    clickColorButton("Minute");
+    expect(colorInput.value).toBe(settings.minuteColor);
+
+    act(() => {
+      colorInput.value = "#123456";
+      colorInput.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    expect(changeDateTimeWidgetSetting).toHaveBeenLastCalledWith("minuteColor", "#123456");
+
+    clickColorButton("Second");
+    expect(colorInput.value).toBe(settings.secondColor);
+    expect(click).toHaveBeenCalledTimes(2);
+
+    function clickColorButton(label: string) {
+      const button = Array.from(container?.querySelectorAll("button") ?? []).find((candidate) =>
+        candidate.textContent?.includes(label)
+      );
+
+      expect(button).toBeDefined();
+      act(() => button?.click());
+    }
+  });
+});

--- a/tests/unit/ui/widgets/rssService.test.ts
+++ b/tests/unit/ui/widgets/rssService.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { defaultCanvasState } from "../../../../src/domain/canvas";
+import { fetchRssItems } from "../../../../src/ui/widgets/rss/rssService";
+
+describe("fetchRssItems", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+  });
+
+  it("limits items per feed before applying the global item limit", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      return new Response(url.includes("feed-a") ? feedXml("A", 5, "2024-01-02") : feedXml("B", 2, "2024-01-01"), {
+        status: 200,
+        headers: { "Content-Type": "application/xml" }
+      });
+    });
+
+    const result = await fetchRssItems({
+      ...defaultCanvasState.widgets.rss.settings,
+      feeds: [
+        { id: "feed-a", title: "Feed A", url: "https://example.com/feed-a.xml" },
+        { id: "feed-b", title: "Feed B", url: "https://example.com/feed-b.xml" }
+      ],
+      feedMode: "all",
+      maxItems: 4,
+      maxItemsPerFeed: 2
+    });
+
+    expect(result.items.map((item) => item.feedId)).toEqual(["feed-a", "feed-a", "feed-b", "feed-b"]);
+  });
+});
+
+function feedXml(prefix: string, count: number, day: string) {
+  const items = Array.from({ length: count }, (_, index) => {
+    const itemNumber = index + 1;
+    return `
+      <item>
+        <title>${prefix} ${itemNumber}</title>
+        <link>https://example.com/${prefix.toLowerCase()}/${itemNumber}</link>
+        <pubDate>${day}T0${count - index}:00:00Z</pubDate>
+        <guid>${prefix}-${itemNumber}</guid>
+      </item>
+    `;
+  }).join("");
+
+  return `<rss version="2.0"><channel><title>Feed ${prefix}</title>${items}</channel></rss>`;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["tests/unit/**/*.test.ts"]
+    include: ["tests/unit/**/*.test.ts", "tests/unit/**/*.test.tsx"]
   }
 });


### PR DESCRIPTION
This PR enhances SnapTab’s widget system and adds full Snap Feed RSS management.

Changes included

- Added Snap Feed Widget as a new Canvas widget.
- Added RSS/Atom feed parsing and feed item normalization.
- Added OPML import/export support for RSS subscriptions.
- Added feed merge and replace flows, with duplicate URL skipping.
- Added feed status checks from the widget context menu.
- Added RSS fetching through a Manifest V3 background service worker.
- Added http/https host permissions for RSS/Atom feed fetching.
- Added feed item thumbnails with fallback to favicon and generated initials.
- Added RSS cache handling with last fetch, last success, and error metadata.
- Added all-feeds and selected-feed modes.
- Added per-feed item limit before applying the global item limit.
- Added RSS widget display modes: compact, standard, and expanded.
- Added default RSS widget placement and persisted settings.
- Added backward-compatible state normalization for older saved states without RSS widget data.
- Improved Weather widget responsiveness and persistent caching.
- Improved Date & Time widget responsiveness and added per-part clock color controls.
- Improved Shortcut Grid sizing when page dots are hidden.
- Improved icon-size behavior so widget capacity is preserved better.
- Added inline folder rename by double-clicking the opened folder title.
- Replaced shortcut edit text buttons with pencil icons.
- Updated docs to reflect Weather, Date & Time, and Snap Feed widgets.
- Added unit and smoke tests for RSS parsing, OPML import/export, widget normalization, responsive widgets, folder rename, and shortcut page transition stability.

Notes
Snap Feed subscriptions are persisted in TabState and included in JSON backups.

- Fetched feed items and feed check results are treated as cache/transient data.
- OPML import/export is scoped only to RSS subscriptions and is separate from JSON backup.
- In Vite dev mode, RSS fetch may still hit CORS because the background service worker is only available in the installed extension.